### PR TITLE
Only limit dependencies by major version changes

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import find_packages, setup
 
 # Dependencies required to use your package
-INSTALL_REQS = ['requests==2.22.0', 'typing_extensions>=3.7.4.2']
+INSTALL_REQS = ['requests>=2.22.0,<3', 'typing_extensions>=3.7.4.2,<4']
 
 # Dependencies required only for running tests
 TEST_REQS = ['pytest', 'pytest-runner', 'pytest-cov']


### PR DESCRIPTION
Only limit dependencies by major version changes to avoid install errors when used in combination with other packages