### PR TITLE
Add example for list of variants in text file

### DIFF
--- a/docs/extra.css
+++ b/docs/extra.css
@@ -1,0 +1,3 @@
+.md-typeset div.arithmatex {
+    overflow: unset !important;
+}

--- a/docs/usage_examples/intro_tutorial.md
+++ b/docs/usage_examples/intro_tutorial.md
@@ -1,7 +1,7 @@
 # Matching Tutorial
 
 This tutorial will cover how to get started using GraphKB to annotate your variants. There is an
-interative/jupyter version of this tutorial ([tutorial.pynb](./tutorial.pynb)) which can be run in a web browser
+interative/jupyter version of this tutorial ([tutorial.ipynb](./tutorial.ipynb)) which can be run in a web browser
 using [google colab](https://colab.research.google.com/github/bcgsc/pori_graphkb_python/blob/master/docs/usage_examples/tutorial.ipynb)
 or a local jupyter server
 

--- a/docs/usage_examples/tutorial.py
+++ b/docs/usage_examples/tutorial.py
@@ -1,5 +1,3 @@
-import os
-
 from graphkb import GraphKBConnection
 from graphkb.constants import BASE_RETURN_PROPERTIES, GENERIC_RETURN_PROPERTIES
 from graphkb.match import match_positional_variant

--- a/docs/usage_examples/variant_strings.md
+++ b/docs/usage_examples/variant_strings.md
@@ -1,0 +1,47 @@
+# Annotate Variant List
+
+The script [annotate_variant_list.py](./annotate_variant_list.py) can be used to match variants from input '=
+files to an instance of GraphKB. Copy the script locally and install the package dependencies.
+
+This example script expects a file with a single field (variant) and no header. Each line should
+be a separate HGVS-like variant notation. For example
+
+```text
+KRAS:p.G12D
+KRAS:p.G13E
+```
+
+!!! note "Must use Python3.6 or higher"
+
+```bash
+pip3 install graphkb pandas
+```
+
+Then the annotator can be run as follows
+
+```bash
+python annotate_variant_list.py <INPUT FILE> --output graphkb_annotations.tsv
+```
+
+By default this will use the pori-demo version of GraphKB which has a limited amount of data. This
+demo version is intended for demonstration/testing only and a custom or shared production instance
+of the GraphKB API. This can be configured via the GraphKB arguments. See the help menu for a full
+list of arguments.
+
+```bash
+python annotate_variant_list.py -h
+```
+
+The output file will contain the variant name and the annotations pulled from GraphKB.
+
+The names of the variants matched will be included in the output file as "variant_matches", this
+will be a semi-colon delimited list of all the variants which were considered to be present/equivalent
+based on the input variant. For example if the input where `KRAS:p.G12D` we might expect to see
+something like this
+
+```text
+KRAS mutation;KRAS:p.(G12_G13)mut;KRAS:p.?12mut;KRAS:p.G12;KRAS:p.G12D;KRAS:p.G12mut;chr12:g.25398284C>T
+```
+
+We can see the variant has matched less specific forms of the same variant such as `KRAS mutation`
+or `KRAS:p.(G12_G13)mut` (any KRAS mutation at G12 or G13)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -13,3 +13,9 @@ extra_javascript:
   - js/mathjax.config.js
   - https://polyfill.io/v3/polyfill.min.js?features=es6
   - https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js
+extra_css:
+  - extra.css
+plugins:
+    - redirects:
+        redirect_maps:
+            'usage_examples/tutorial.md': 'usage_examples/intro_tutorial.md' # support old links

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ INSTALL_REQS = ['requests>=2.22.0,<3', 'typing_extensions>=3.7.4.2,<4']
 # Dependencies required only for running tests
 TEST_REQS = ['pytest', 'pytest-runner', 'pytest-cov']
 
-DOC_REQS = ['mkdocs', 'markdown_refdocs', 'mkdocs-material']
+DOC_REQS = ['mkdocs', 'markdown_refdocs', 'mkdocs-material', 'mkdocs-redirects']
 
 # Dependencies required for deploying to an index server
 DEPLOYMENT_REQS = ['twine', 'wheel']


### PR DESCRIPTION
Another Doc update 
- add a different example script to use the super simple input format that is just a variant name per line
- Fix weird deployment CSS bug where equations have scroll bars (doesn't happen locally)
- Fix typo in local python notebook link