### PR TITLE
Fix typo in extras require in workflow

### DIFF
--- a/.github/workflows/publishdevdocs.yml
+++ b/.github/workflows/publishdevdocs.yml
@@ -21,8 +21,7 @@ jobs:
     - name: install and build
       run: |
         python -m pip install --upgrade pip setuptools
-        pip install .[docs]
-        pip install markdown_refdocs mkdocs mkdocs-material
+        pip install .[doc]
         markdown_refdocs graphkb -o docs/reference --link
         mkdocs build
     - name: Deploy


### PR DESCRIPTION
This typo has been around for a while but we've only run into it now b/c a doc specific dependency was added

typo was `.[docs]` should have been `.[doc]`