### PR TITLE
Refactor - group constants into constants.py

### DIFF
--- a/graphkb/__init__.py
+++ b/graphkb/__init__.py
@@ -1,1 +1,2 @@
 from .util import GraphKBConnection, logger
+from .constants import DEFAULT_URL

--- a/graphkb/constants.py
+++ b/graphkb/constants.py
@@ -18,6 +18,14 @@ GENERIC_RETURN_PROPERTIES = [
     'deprecated',
 ] + BASE_RETURN_PROPERTIES
 
+GENE_RETURN_PROPERTIES = ['biotype'] + GENERIC_RETURN_PROPERTIES
+
+
+ONCOKB_SOURCE_NAME = 'oncokb'
+ONCOGENE = 'oncogenic'
+TUMOUR_SUPPRESSIVE = 'tumour suppressive'
+
+FUSION_NAMES = ['structural variant', 'fusion']
 BASE_THERAPEUTIC_TERMS = ['therapeutic efficacy', 'eligibility']
 # the order here is the order these are applied, the first category matched is returned
 RELEVANCE_BASE_TERMS: CategoryBaseTermMapping = [

--- a/graphkb/constants.py
+++ b/graphkb/constants.py
@@ -1,3 +1,5 @@
+import argparse
+
 from .types import CategoryBaseTermMapping
 
 DEFAULT_LIMIT = 1000
@@ -20,6 +22,28 @@ GENERIC_RETURN_PROPERTIES = [
 
 GENE_RETURN_PROPERTIES = ['biotype'] + GENERIC_RETURN_PROPERTIES
 
+VARIANT_RETURN_PROPERTIES = (
+    BASE_RETURN_PROPERTIES
+    + [f'type.{p}' for p in GENERIC_RETURN_PROPERTIES]
+    + [f'reference1.{p}' for p in GENE_RETURN_PROPERTIES]
+    + [f'reference2.{p}' for p in GENE_RETURN_PROPERTIES]
+    + ['zygosity', 'germline', 'displayName']
+)
+
+POS_VARIANT_RETURN_PROPERTIES = VARIANT_RETURN_PROPERTIES + [
+    'break1Start',
+    'break1End',
+    'break2Start',
+    'break2End',
+    'break1Repr',
+    'break2Repr',
+    'refSeq',
+    'untemplatedSeq',
+    'untemplatedSeqSize',
+    'truncation',
+    'assembly',
+]
+
 
 ONCOKB_SOURCE_NAME = 'oncokb'
 ONCOGENE = 'oncogenic'
@@ -37,6 +61,8 @@ RELEVANCE_BASE_TERMS: CategoryBaseTermMapping = [
     ('biological', ['functional effect', 'tumourigenesis', 'predisposing']),
 ]
 
+
+AMBIGUOUS_AA = ['x', '?', 'X']
 AA_3to1_MAPPING = {
     'Ala': 'A',
     'Arg': 'R',
@@ -62,3 +88,33 @@ AA_3to1_MAPPING = {
     'Val': 'V',
     'Ter': '*',
 }
+
+
+class IterableNamespace(argparse.Namespace):
+    def __init__(self, *pos, **kwargs):
+        argparse.Namespace.__init__(self, *pos, **kwargs)
+
+    def keys(self):
+        return self.__dict__.keys()
+
+    def items(self):
+        return self.__dict__.items()
+
+    def values(self):
+        return self.__dict__.values()
+
+    def __getitem__(self, key):
+        return getattr(self, key)
+
+
+INPUT_COPY_CATEGORIES = IterableNamespace(
+    AMP='amplification',
+    ANY_GAIN='copy gain',
+    ANY_LOSS='copy loss',
+    DEEP='deep deletion',
+    GAIN='low level copy gain',
+    LOSS='shallow deletion',
+)
+INPUT_EXPRESSION_CATEGORIES = IterableNamespace(
+    UP='increased expression', DOWN='reduced expression'
+)

--- a/graphkb/genes.py
+++ b/graphkb/genes.py
@@ -4,26 +4,8 @@ Methods for retrieving gene annotation lists from GraphKB
 from typing import Any, Dict, List, cast
 
 from . import GraphKBConnection
+from .constants import GENE_RETURN_PROPERTIES, ONCOGENE, ONCOKB_SOURCE_NAME, TUMOUR_SUPPRESSIVE
 from .types import Ontology, Statement, Variant
-
-ONCOKB_SOURCE_NAME = 'oncokb'
-ONCOGENE = 'oncogenic'
-TUMOUR_SUPPRESSIVE = 'tumour suppressive'
-
-FUSION_NAMES = ['structural variant', 'fusion']
-
-GENE_RETURN_PROPERTIES = [
-    'name',
-    '@rid',
-    '@class',
-    'sourceId',
-    'sourceIdVersion',
-    'source.name',
-    'source.@rid',
-    'displayName',
-    'biotype',
-    'deprecated',
-]
 
 
 def _get_oncokb_gene_list(

--- a/graphkb/match.py
+++ b/graphkb/match.py
@@ -4,8 +4,7 @@ Functions which return Variants from GraphKB which match some input variant defi
 from typing import Dict, List, Optional, Set, Union, cast
 
 from . import GraphKBConnection
-from .constants import BASE_RETURN_PROPERTIES, GENERIC_RETURN_PROPERTIES
-from .genes import GENE_RETURN_PROPERTIES
+from .constants import BASE_RETURN_PROPERTIES, GENE_RETURN_PROPERTIES, GENERIC_RETURN_PROPERTIES
 from .types import BasicPosition, Ontology, ParsedVariant, PositionalVariant, Record, Variant
 from .util import FeatureNotFoundError, IterableNamespace, convert_to_rid_list, looks_like_rid
 from .vocab import get_term_tree

--- a/graphkb/match.py
+++ b/graphkb/match.py
@@ -4,46 +4,16 @@ Functions which return Variants from GraphKB which match some input variant defi
 from typing import Dict, List, Optional, Set, Union, cast
 
 from . import GraphKBConnection
-from .constants import BASE_RETURN_PROPERTIES, GENE_RETURN_PROPERTIES, GENERIC_RETURN_PROPERTIES
+from .constants import (
+    AMBIGUOUS_AA,
+    INPUT_COPY_CATEGORIES,
+    INPUT_EXPRESSION_CATEGORIES,
+    POS_VARIANT_RETURN_PROPERTIES,
+    VARIANT_RETURN_PROPERTIES,
+)
 from .types import BasicPosition, Ontology, ParsedVariant, PositionalVariant, Record, Variant
-from .util import FeatureNotFoundError, IterableNamespace, convert_to_rid_list, looks_like_rid
+from .util import FeatureNotFoundError, convert_to_rid_list, looks_like_rid
 from .vocab import get_term_tree
-
-INPUT_COPY_CATEGORIES = IterableNamespace(
-    AMP='amplification',
-    ANY_GAIN='copy gain',
-    ANY_LOSS='copy loss',
-    DEEP='deep deletion',
-    GAIN='low level copy gain',
-    LOSS='shallow deletion',
-)
-INPUT_EXPRESSION_CATEGORIES = IterableNamespace(
-    UP='increased expression', DOWN='reduced expression'
-)
-AMBIGUOUS_AA = ['x', '?', 'X']
-
-VARIANT_RETURN_PROPERTIES = (
-    BASE_RETURN_PROPERTIES
-    + [f'type.{p}' for p in GENERIC_RETURN_PROPERTIES]
-    + [f'reference1.{p}' for p in GENE_RETURN_PROPERTIES]
-    + [f'reference2.{p}' for p in GENE_RETURN_PROPERTIES]
-    + ['zygosity', 'germline', 'displayName']
-)
-
-POS_VARIANT_RETURN_PROPERTIES = VARIANT_RETURN_PROPERTIES + [
-    'break1Start',
-    'break1End',
-    'break2Start',
-    'break2End',
-    'break1Repr',
-    'break2Repr',
-    'refSeq',
-    'untemplatedSeq',
-    'untemplatedSeqSize',
-    'truncation',
-    'assembly',
-]
-
 
 FEATURES_CACHE: Set[str] = set()
 

--- a/graphkb/util.py
+++ b/graphkb/util.py
@@ -1,4 +1,3 @@
-import argparse
 import hashlib
 import json
 import logging
@@ -19,23 +18,6 @@ QUERY_CACHE: Dict[Any, Any] = {}
 # https://stackoverflow.com/questions/11029717/how-do-i-disable-log-messages-from-the-requests-library
 
 logger = logging.getLogger('graphkb')
-
-
-class IterableNamespace(argparse.Namespace):
-    def __init__(self, *pos, **kwargs):
-        argparse.Namespace.__init__(self, *pos, **kwargs)
-
-    def keys(self):
-        return self.__dict__.keys()
-
-    def items(self):
-        return self.__dict__.items()
-
-    def values(self):
-        return self.__dict__.values()
-
-    def __getitem__(self, key):
-        return getattr(self, key)
 
 
 def convert_to_rid_list(records: Iterable[Record]) -> List[str]:

--- a/graphkb/util.py
+++ b/graphkb/util.py
@@ -66,23 +66,17 @@ def convert_aa_3to1(three_letter_notation: str) -> str:
 
 
 def join_url(base_url: str, *parts) -> str:
-    """
-    Join parts of a URL into a full URL
-    """
+    """Join parts of a URL into a full URL."""
     if not parts:
         return base_url
 
-    url = [base_url.rstrip('/')]
+    url = [base_url.rstrip('/')] + [part.strip('/') for part in parts]
 
-    for part in parts:
-        if not part.startswith('/'):
-            url.append('/')
-        url.append(part)
-    return ''.join(url)
+    return '/'.join(url)
 
 
 def millis_interval(start: datetime, end: datetime) -> int:
-    """start and end are datetime instances"""
+    """Millisecond time from start and end datetime instances."""
     diff = end - start
     millis = diff.days * 24 * 60 * 60 * 1000
     millis += diff.seconds * 1000

--- a/graphkb/util.py
+++ b/graphkb/util.py
@@ -90,10 +90,7 @@ def join_url(base_url: str, *parts) -> str:
     if not parts:
         return base_url
 
-    if base_url.endswith('/'):
-        base_url = base_url[:-1]
-
-    url = [base_url]
+    url = [base_url.rstrip('/')]
 
     for part in parts:
         if not part.startswith('/'):
@@ -111,7 +108,7 @@ def millis_interval(start: datetime, end: datetime) -> int:
     return millis
 
 
-def cache_key(request_body):
+def cache_key(request_body) -> str:
     """Create a cache key for a query request to GraphKB."""
     body = json.dumps(request_body, sort_keys=True)
     hash_code = hashlib.md5(f'/query{body}'.encode('utf-8')).hexdigest()

--- a/graphkb/util.py
+++ b/graphkb/util.py
@@ -98,20 +98,28 @@ def cache_key(request_body) -> str:
 
 
 class GraphKBConnection:
-    def __init__(self, url: str = DEFAULT_URL, use_global_cache: bool = True):
+    def __init__(
+        self,
+        url: str = DEFAULT_URL,
+        username: str = '',
+        password: str = '',
+        use_global_cache: bool = True,
+    ):
         self.http = requests.Session()
         retries = Retry(total=3, backoff_factor=1, status_forcelist=[429, 500, 502, 503, 504])
         self.http.mount("https://", HTTPAdapter(max_retries=retries))
 
         self.token = ''
         self.url = url
-        self.username = ''
-        self.password = ''
+        self.username = username
+        self.password = password
         self.headers = {'Accept': 'application/json', 'Content-Type': 'application/json'}
         self.cache: Dict[Any, Any] = {} if not use_global_cache else QUERY_CACHE
         self.request_count = 0
         self.first_request: Optional[datetime] = None
         self.last_request: Optional[datetime] = None
+        if username and password:
+            self.login(username=username, password=password)
 
     @property
     def load(self) -> Optional[float]:

--- a/tests/test_genes.py
+++ b/tests/test_genes.py
@@ -5,7 +5,13 @@ import os
 
 import pytest
 
-from graphkb import GraphKBConnection, genes
+from graphkb import GraphKBConnection
+from graphkb.constants import FUSION_NAMES
+from graphkb.genes import (
+    get_genes_from_variant_types,
+    get_oncokb_oncogenes,
+    get_oncokb_tumour_supressors,
+)
 
 CANONICAL_ONCOGENES = ['kras', 'nras', 'alk']
 CANONICAL_TS = ['cdkn2a', 'tp53']
@@ -21,7 +27,7 @@ def conn():
 
 @pytest.mark.parametrize('gene', CANONICAL_ONCOGENES)
 def test_finds_oncogene(conn, gene):
-    result = genes.get_oncokb_oncogenes(conn)
+    result = get_oncokb_oncogenes(conn)
 
     names = {row['name'] for row in result}
     assert gene in names
@@ -29,7 +35,7 @@ def test_finds_oncogene(conn, gene):
 
 @pytest.mark.parametrize('gene', CANONICAL_TS)
 def test_ts_not_oncogene(conn, gene):
-    result = genes.get_oncokb_oncogenes(conn)
+    result = get_oncokb_oncogenes(conn)
 
     names = {row['name'] for row in result}
     assert gene not in names
@@ -37,7 +43,7 @@ def test_ts_not_oncogene(conn, gene):
 
 @pytest.mark.parametrize('gene', CANONICAL_ONCOGENES)
 def test_oncogene_not_ts(conn, gene):
-    result = genes.get_oncokb_tumour_supressors(conn)
+    result = get_oncokb_tumour_supressors(conn)
 
     names = {row['name'] for row in result}
     assert gene not in names
@@ -45,7 +51,7 @@ def test_oncogene_not_ts(conn, gene):
 
 @pytest.mark.parametrize('gene', CANONICAL_TS)
 def test_finds_ts(conn, gene):
-    result = genes.get_oncokb_tumour_supressors(conn)
+    result = get_oncokb_tumour_supressors(conn)
 
     names = {row['name'] for row in result}
     assert gene in names
@@ -53,6 +59,6 @@ def test_finds_ts(conn, gene):
 
 @pytest.mark.parametrize('gene', CANONICAL_FUSION_GENES)
 def test_find_fusion_genes(conn, gene):
-    result = genes.get_genes_from_variant_types(conn, genes.FUSION_NAMES)
+    result = get_genes_from_variant_types(conn, FUSION_NAMES)
     names = {row['name'] for row in result}
     assert gene in names


### PR DESCRIPTION
Moving constants to constants.py makes related return properties more clear.

GraphKBConnection.__init__ will login if given a username and password.