### PR TITLE
Bugfix/gero 303 promoter matches missed without leading 1

### DIFF
--- a/graphkb/__init__.py
+++ b/graphkb/__init__.py
@@ -1,2 +1,2 @@
-from .util import GraphKBConnection, logger
 from .constants import DEFAULT_URL
+from .util import GraphKBConnection, logger

--- a/graphkb/match.py
+++ b/graphkb/match.py
@@ -171,8 +171,7 @@ def match_category_variant(
 def match_copy_variant(
     conn: GraphKBConnection, gene_name: str, category: str, drop_homozygous: bool = False, **kwargs
 ) -> List[Variant]:
-    """
-    Returns a list of variants matching the input variant
+    """Returns a list of copy number GraphKB matches for the copy_category of the gene_name.
 
     Args:
         conn (GraphKBConnection): the graphkb connection object

--- a/tests/test_match.py
+++ b/tests/test_match.py
@@ -389,7 +389,7 @@ class TestMatchPositionalVariant:
         matches = match.match_positional_variant(conn, known)
         assert not matches
 
-    def test_movel_specific_matches_general(self, conn):
+    def test_novel_specific_matches_general(self, conn):
         novel_specific = 'CDKN2A:p.T18888888888888888888M'
         matches = match.match_positional_variant(conn, novel_specific)
         names = {m['displayName'] for m in matches}
@@ -401,6 +401,12 @@ class TestMatchPositionalVariant:
         genomic = 'X:g.100611165A>T'
         match.match_positional_variant(conn, genomic)
         # no assert b/c checking for no error rather than the result
+
+    def test_tert_promoter(self, conn):
+        assert match.match_positional_variant(conn, 'TERT:c.-124C>T')
+
+    def test_tert_promoter_leading_one_alt_notation(self, conn):
+        assert match.match_positional_variant(conn, 'TERT:c.1-124C>T')
 
     @pytest.mark.skipif(True, reason="TODO: GERO-299 incomplete; cds and genomic fail test.")
     def test_missense_is_not_nonsense(self, conn):


### PR DESCRIPTION
Also related to KBDEV-990

I'm not sure about the solution in util.py, given the comments on KBDEV-990.

We might want to cherry pick out the changes to test_match.py, then verify a proper solution.