### PR TITLE
Feature/sdev 3256 gene list updates pharma cancer predisp

### DIFF
--- a/graphkb/constants.py
+++ b/graphkb/constants.py
@@ -3,12 +3,12 @@ import argparse
 from .types import CategoryBaseTermMapping
 
 DEFAULT_LIMIT = 1000
-
 GKB_BASE_URL = "https://graphkb-api.bcgsc.ca/api"
 GKB_STAGING_URL = "https://graphkbstaging-api.bcgsc.ca/api"
 GKB_DEV_URL = "https://graphkbdev-api.bcgsc.ca/api"
 DEFAULT_URL = GKB_BASE_URL
 
+PREFERRED_GENE_SOURCE = "#39:5"  # HGNC
 
 BASE_RETURN_PROPERTIES = ['@rid', '@class']
 
@@ -75,6 +75,10 @@ RELEVANCE_BASE_TERMS: CategoryBaseTermMapping = [
     ('cancer predisposition', ['pathogenic']),
     ('biological', ['functional effect', 'tumourigenesis', 'predisposing']),
 ]
+
+CHROMOSOMES_HG38 = [f"chr{i}" for i in range(1, 23)] + ['chrX', 'chrY', 'chrM']
+CHROMOSOMES_HG19 = [str(i) for i in range(1, 23)] + ['x', 'y', 'mt']
+CHROMOSOMES = CHROMOSOMES_HG38 + CHROMOSOMES_HG19
 
 AMBIGUOUS_AA = ['x', '?', 'X']
 AA_3to1_MAPPING = {

--- a/graphkb/constants.py
+++ b/graphkb/constants.py
@@ -62,7 +62,7 @@ ONCOKB_SOURCE_NAME = 'oncokb'
 ONCOGENE = 'oncogenic'
 TUMOUR_SUPPRESSIVE = 'tumour suppressive'
 FUSION_NAMES = ['structural variant', 'fusion']
-PHARMACOGENOMIC_RELEVANCE_TERMS = ["decreased toxicity", "increased toxicity"]
+
 PHARMACOGENOMIC_SOURCE_EXCLUDE_LIST = ["cancer genome interpreter", "civic"]
 
 BASE_THERAPEUTIC_TERMS = ['therapeutic efficacy', 'eligibility']

--- a/graphkb/constants.py
+++ b/graphkb/constants.py
@@ -56,8 +56,10 @@ STATEMENT_RETURN_PROPERTIES = (
 ONCOKB_SOURCE_NAME = 'oncokb'
 ONCOGENE = 'oncogenic'
 TUMOUR_SUPPRESSIVE = 'tumour suppressive'
-
 FUSION_NAMES = ['structural variant', 'fusion']
+PHARMACOGENOMIC_RELEVANCE_TERMS = ["decreased toxicity", "increased toxicity"]
+PHARMACOGENOMIC_SOURCE_EXCLUDE_LIST = ["cancer genome interpreter", "civic"]
+
 BASE_THERAPEUTIC_TERMS = ['therapeutic efficacy', 'eligibility']
 # the order here is the order these are applied, the first category matched is returned
 RELEVANCE_BASE_TERMS: CategoryBaseTermMapping = [

--- a/graphkb/genes.py
+++ b/graphkb/genes.py
@@ -1,11 +1,21 @@
 """
 Methods for retrieving gene annotation lists from GraphKB
 """
-from typing import Any, Dict, List, cast
+from typing import Any, Dict, List, Tuple, cast
 
 from . import GraphKBConnection
-from .constants import GENE_RETURN_PROPERTIES, ONCOGENE, ONCOKB_SOURCE_NAME, TUMOUR_SUPPRESSIVE
+from .constants import (
+    GENE_RETURN_PROPERTIES,
+    ONCOGENE,
+    ONCOKB_SOURCE_NAME,
+    PHARMACOGENOMIC_RELEVANCE_TERMS,
+    PHARMACOGENOMIC_SOURCE_EXCLUDE_LIST,
+    RELEVANCE_BASE_TERMS,
+    TUMOUR_SUPPRESSIVE,
+)
+from .match import get_equivalent_features
 from .types import Ontology, Statement, Variant
+from .util import get_rid, logger
 
 
 def _get_oncokb_gene_list(
@@ -117,3 +127,210 @@ def get_genes_from_variant_types(
         ),
     )
     return result
+
+
+def get_term_list(target_category) -> List[str]:
+    """Load the relevance terms for 'cancer predisposition' variants."""
+    for category, base_terms in RELEVANCE_BASE_TERMS:
+        if category == target_category and base_terms:
+            return base_terms
+    else:
+        raise AssertionError(f"Undefined '{target_category}' category")
+
+
+def get_preferred_gene_name(conn: GraphKBConnection, gene_name: str, source: str = '#39:5') -> str:
+    """Preferred gene symbol of a gene or transcript.
+
+    Args:
+        gene_name: the gene name to search features by
+        ignore_cache (bool, optional): bypass the cache to always force a new request
+        source: id of the preferred gene symbol source
+    Returns:
+        preferred displayName symbol.
+
+    Example:
+        return KRAS for get_preferred_gene_name(conn, 'NM_033360')
+        return KRAS for get_preferred_gene_name(conn, 'ENSG00000133703.11')
+    """
+    eq = get_equivalent_features(conn=conn, gene_name=gene_name)
+    genes = [m for m in eq if m.get('biotype', '') == 'gene' and not m.get('deprecated', False)]
+    if not genes:
+        logger.error(f"No genes found for: {gene_name}")
+        return ''
+    if source:
+        source_filtered_genes = [m for m in genes if m.get('source', '') == source]
+        if not source_filtered_genes:
+            logger.error(f"No data from source {source} for {gene_name}")
+        else:
+            genes = source_filtered_genes
+
+    gene_names = [g['displayName'] for g in genes if g]
+    if len(gene_names) > 1:
+        logger.error(
+            f"Multiple gene names found for: {gene_name} - using {gene_names[0]}, ignoring {gene_names[1:]}"
+        )
+    return gene_names[0]
+
+
+def get_cancer_predisposition_info(conn: GraphKBConnection) -> Tuple[List[str], Dict[str, str]]:
+    """
+    Return two lists from GraphKB, one of cancer predisposition genes and one of associated variants.
+
+    GERO-272 - criteria for what counts as a "cancer predisposition" variant
+
+    In short:
+    * Statement 'source' is 'CGL'
+    * Statement 'relevance' is 'pathogenic'
+    * gene is gotten from any associated 'PositionalVariant' records
+
+    Example: https://graphkb.bcgsc.ca/view/Statement/155:11616
+
+    Returns:
+        genes: list of cancer predisposition genes
+        variants: dictionary mapping pharmacogenomic variant IDs to variant display names
+    """
+    genes = set()
+    non_genes = set()
+    infer_genes = set()
+    variants = {}
+
+    relevance = get_term_list("cancer predisposition")
+
+    for record in conn.query(
+        {
+            "target": "Statement",
+            "filters": [
+                {
+                    "evidence": {
+                        "target": "Source",
+                        "filters": {"@rid": get_rid(conn, "Source", "CGL")},
+                    },
+                    "relevance": {
+                        "target": "Vocabulary",
+                        "filters": {
+                            "@rid": [get_rid(conn, "Vocabulary", term) for term in relevance]
+                        },
+                    },
+                }
+            ],
+            "returnProperties": [
+                "conditions.@class",
+                "conditions.@rid",
+                "conditions.displayName",
+                "conditions.reference1.biotype",
+                "conditions.reference1.displayName",
+                "conditions.reference2.biotype",
+                "conditions.reference2.displayName",
+            ],
+        },
+        ignore_cache=False,
+    ):
+        for condition in record["conditions"]:  # type: ignore
+            if condition["@class"] == "PositionalVariant":
+                variants[condition["@rid"]] = condition["displayName"]
+                for reference in ["reference1", "reference2"]:
+                    name = (condition.get(reference) or {}).get("displayName", "")
+                    biotype = (condition.get(reference) or {}).get("biotype", "")
+                    if name and biotype == "gene":
+                        genes.add(name)
+                    elif name:
+                        gene = get_preferred_gene_name(conn, name)
+                        if gene:
+                            infer_genes.add((gene, name, biotype))
+                        else:
+                            non_genes.add((name, biotype))
+                            logger.error(
+                                f"Non-gene cancer predisposition {biotype}: {name} for {condition['displayName']}"
+                            )
+
+    for gene, name, biotype in infer_genes:
+        logger.debug(f"Found gene '{gene}' for '{name}' ({biotype})")
+        genes.add(gene)
+
+    for name, biotype in non_genes:
+        logger.error(f"Unable to find gene for '{name}' ({biotype})")
+
+    return sorted(genes), variants
+
+
+def get_pharmacogenomic_info(conn: GraphKBConnection) -> Tuple[List[str], Dict[str, str]]:
+    """
+    Return two lists from GraphKB, one of pharmacogenomic genes and one of associated variants.
+
+    SDEV-2733 - criteria for what counts as a "pharmacogenomic" variant
+
+    In short:
+    * Statement 'source' is not 'CGI' or 'CIViC'
+    * Statement 'relevance' is 'increased toxicity' or 'decreased toxicity'
+    * gene is gotten from any associated 'PositionalVariant' records
+
+    Example: https://graphkb.bcgsc.ca/view/Statement/154:9574
+
+    Returns:
+        genes: list of pharmacogenomic genes
+        variants: dictionary mapping pharmacogenomic variant IDs to variant display names
+    """
+    genes = set()
+    non_genes = set()
+    infer_genes = set()
+    variants = {}
+
+    for record in conn.query(
+        {
+            "target": "Statement",
+            "filters": [
+                {
+                    "relevance": {
+                        "target": "Vocabulary",
+                        "filters": {
+                            "@rid": [
+                                get_rid(conn, "Vocabulary", term)
+                                for term in PHARMACOGENOMIC_RELEVANCE_TERMS
+                            ]
+                        },
+                    }
+                }
+            ],
+            "returnProperties": [
+                "conditions.@class",
+                "conditions.@rid",
+                "conditions.displayName",
+                "conditions.reference1.biotype",
+                "conditions.reference1.displayName",
+                "conditions.reference2.biotype",
+                "conditions.reference2.displayName",
+                "source.name",
+            ],
+        },
+        ignore_cache=False,
+    ):
+        if record["source"]:  # type: ignore
+            if record["source"]["name"].lower() in PHARMACOGENOMIC_SOURCE_EXCLUDE_LIST:  # type: ignore
+                continue
+
+        for condition in record["conditions"]:  # type: ignore
+            if condition["@class"] == "PositionalVariant":
+                variants[condition["@rid"]] = condition["displayName"]
+                for reference in ["reference1", "reference2"]:
+                    name = (condition.get(reference) or {}).get("displayName", "")
+                    biotype = (condition.get(reference) or {}).get("biotype", "")
+                    if name and biotype == "gene":
+                        genes.add(name)
+                    elif name:
+                        gene = get_preferred_gene_name(conn, name)
+                        if gene:
+                            infer_genes.add((gene, name, biotype))
+                        else:
+                            non_genes.add((name, biotype))
+                            logger.error(
+                                f"Non-gene pharmacogenomic {biotype}: {name} for {condition['displayName']}"
+                            )
+
+    for gene, name, biotype in infer_genes:
+        logger.debug(f"Found gene '{gene}' for '{name}' ({biotype})")
+        genes.add(gene)
+
+    for name, biotype in non_genes:
+        logger.error(f"Unable to find gene for '{name}' ({biotype})")
+
+    return sorted(genes), variants

--- a/graphkb/genes.py
+++ b/graphkb/genes.py
@@ -186,12 +186,12 @@ def get_preferred_gene_name(
         logger.error(f"{gene_name} assumed to be a chromosome, not gene")
         return ''
     eq = get_equivalent_features(conn=conn, gene_name=gene_name)
-    genes = [m for m in eq if m.get('biotype', '') == 'gene' and not m.get('deprecated', False)]
+    genes = [m for m in eq if m.get('biotype') == 'gene' and not m.get('deprecated')]
     if not genes:
         logger.error(f"No genes found for: {gene_name}")
         return ''
     if source:
-        source_filtered_genes = [m for m in genes if m.get('source', '') == source]
+        source_filtered_genes = [m for m in genes if m.get('source') == source]
         if not source_filtered_genes:
             logger.error(f"No data from source {source} for {gene_name}")
         else:

--- a/graphkb/genes.py
+++ b/graphkb/genes.py
@@ -6,10 +6,12 @@ from typing import Any, Dict, List, Tuple, cast
 from . import GraphKBConnection
 from .constants import (
     BASE_THERAPEUTIC_TERMS,
+    CHROMOSOMES,
     GENE_RETURN_PROPERTIES,
     ONCOGENE,
     ONCOKB_SOURCE_NAME,
     PHARMACOGENOMIC_SOURCE_EXCLUDE_LIST,
+    PREFERRED_GENE_SOURCE,
     TUMOUR_SUPPRESSIVE,
 )
 from .match import get_equivalent_features
@@ -164,7 +166,9 @@ def get_genes_from_variant_types(
     return result
 
 
-def get_preferred_gene_name(conn: GraphKBConnection, gene_name: str, source: str = '#39:5') -> str:
+def get_preferred_gene_name(
+    conn: GraphKBConnection, gene_name: str, source: str = PREFERRED_GENE_SOURCE
+) -> str:
     """Preferred gene symbol of a gene or transcript.
 
     Args:
@@ -178,7 +182,6 @@ def get_preferred_gene_name(conn: GraphKBConnection, gene_name: str, source: str
         return KRAS for get_preferred_gene_name(conn, 'NM_033360')
         return KRAS for get_preferred_gene_name(conn, 'ENSG00000133703.11')
     """
-    CHROMOSOMES = [f"chr{i}" for i in range(1, 24)] + ['chrX', 'chrY']
     if gene_name in CHROMOSOMES:
         logger.error(f"{gene_name} assumed to be a chromosome, not gene")
         return ''

--- a/graphkb/genes.py
+++ b/graphkb/genes.py
@@ -10,7 +10,6 @@ from .constants import (
     ONCOGENE,
     ONCOKB_SOURCE_NAME,
     PHARMACOGENOMIC_SOURCE_EXCLUDE_LIST,
-    RELEVANCE_BASE_TERMS,
     TUMOUR_SUPPRESSIVE,
 )
 from .match import get_equivalent_features
@@ -163,15 +162,6 @@ def get_genes_from_variant_types(
         ),
     )
     return result
-
-
-def get_term_list(target_category) -> List[str]:
-    """Load the relevance terms for 'cancer predisposition' variants."""
-    for category, base_terms in RELEVANCE_BASE_TERMS:
-        if category == target_category and base_terms:
-            return base_terms
-    else:
-        raise AssertionError(f"Undefined '{target_category}' category")
 
 
 def get_preferred_gene_name(conn: GraphKBConnection, gene_name: str, source: str = '#39:5') -> str:

--- a/graphkb/match.py
+++ b/graphkb/match.py
@@ -88,40 +88,6 @@ def get_equivalent_features(
     )
 
 
-def get_preferred_gene_name(conn: GraphKBConnection, gene_name: str, source: str = '#39:5') -> str:
-    """Preferred gene symbol of a gene or transcript.
-
-    Args:
-        gene_name: the gene name to search features by
-        ignore_cache (bool, optional): bypass the cache to always force a new request
-        source: id of the preferred gene symbol source
-    Returns:
-        preferred displayName symbol.
-
-    Example:
-        return KRAS for get_preferred_gene_name(conn, 'NM_033360')
-        return KRAS for get_preferred_gene_name(conn, 'ENSG00000133703.11')
-    """
-    eq = get_equivalent_features(conn=conn, gene_name=gene_name)
-    genes = [m for m in eq if m.get('biotype', '') == 'gene' and not m.get('deprecated', False)]
-    if not genes:
-        logger.error(f"No genes found for: {gene_name}")
-        return ''
-    if source:
-        source_filtered_genes = [m for m in genes if m.get('source', '') == source]
-        if not source_filtered_genes:
-            logger.error(f"No data from source {source} for {gene_name}")
-        else:
-            genes = source_filtered_genes
-
-    gene_names = [g['displayName'] for g in genes if g]
-    if len(gene_names) > 1:
-        logger.error(
-            f"Multiple gene names found for: {gene_name} - using {gene_names[0]}, ignoring {gene_names[1:]}"
-        )
-    return gene_names[0]
-
-
 def cache_missing_features(conn: GraphKBConnection) -> None:
     """
     Create a cache of features that exist to avoid repeatedly querying

--- a/graphkb/match.py
+++ b/graphkb/match.py
@@ -26,8 +26,7 @@ def get_equivalent_features(
     source: str = '',
     source_id_version: str = '',
 ) -> List[Ontology]:
-    """
-    Match an equivalent list of features given some input feature name (or ID)
+    """Match an equivalent list of features given some input feature name (or ID).
 
     Args:
         gene_name: the gene name to search features by
@@ -87,6 +86,40 @@ def get_equivalent_features(
             ignore_cache=ignore_cache,
         ),
     )
+
+
+def get_preferred_gene_name(conn: GraphKBConnection, gene_name: str, source: str = '#39:5') -> str:
+    """Preferred gene symbol of a gene or transcript.
+
+    Args:
+        gene_name: the gene name to search features by
+        ignore_cache (bool, optional): bypass the cache to always force a new request
+        source: id of the preferred gene symbol source
+    Returns:
+        preferred displayName symbol.
+
+    Example:
+        return KRAS for get_preferred_gene_name(conn, 'NM_033360')
+        return KRAS for get_preferred_gene_name(conn, 'ENSG00000133703.11')
+    """
+    eq = get_equivalent_features(conn=conn, gene_name=gene_name)
+    genes = [m for m in eq if m.get('biotype', '') == 'gene' and not m.get('deprecated', False)]
+    if not genes:
+        logger.error(f"No genes found for: {gene_name}")
+        return ''
+    if source:
+        source_filtered_genes = [m for m in genes if m.get('source', '') == source]
+        if not source_filtered_genes:
+            logger.error(f"No data from source {source} for {gene_name}")
+        else:
+            genes = source_filtered_genes
+
+    gene_names = [g['displayName'] for g in genes if g]
+    if len(gene_names) > 1:
+        logger.error(
+            f"Multiple gene names found for: {gene_name} - using {gene_names[0]}, ignoring {gene_names[1:]}"
+        )
+    return gene_names[0]
 
 
 def cache_missing_features(conn: GraphKBConnection) -> None:

--- a/graphkb/match.py
+++ b/graphkb/match.py
@@ -12,7 +12,7 @@ from .constants import (
     VARIANT_RETURN_PROPERTIES,
 )
 from .types import BasicPosition, Ontology, ParsedVariant, PositionalVariant, Record, Variant
-from .util import FeatureNotFoundError, convert_to_rid_list, looks_like_rid
+from .util import FeatureNotFoundError, convert_to_rid_list, logger, looks_like_rid
 from .vocab import get_term_tree
 
 FEATURES_CACHE: Set[str] = set()
@@ -62,14 +62,19 @@ def get_equivalent_features(
     if source:
         filters.append({'source': {'target': 'Source', 'filters': {'name': source}}})
 
+    if gene_name.count('.') == 1 and gene_name.split('.')[-1].isnumeric():
+        # eg. ENSG00000133703.11 or NM_033360.4
+        logger.debug(
+            f"Assuming {gene_name} has a .version_format - ignoring the version for equivalent features"
+        )
+        gene_name = gene_name.split('.')[0]
+
     if is_source_id or source_id_version:
         filters.append({'sourceId': gene_name})
-
         if source_id_version:
             filters.append(
                 {'OR': [{'sourceIdVersion': source_id_version}, {'sourceIdVersion': None}]}
             )
-
     elif FEATURES_CACHE and gene_name.lower() not in FEATURES_CACHE and not ignore_cache:
         return []
     else:

--- a/graphkb/util.py
+++ b/graphkb/util.py
@@ -248,3 +248,27 @@ class GraphKBConnection:
         if len(source) != 1:
             raise AssertionError(f'Unable to unqiuely identify source with name {name}')
         return source[0]
+
+
+def get_rid(conn: GraphKBConnection, target: str, name: str) -> str:
+    """
+    Retrieve a record by name and target
+
+    Args:
+        conn: GraphKBConnection
+        target: record type to query
+        name: the name of the record to retrieve
+
+    Returns:
+        str: @rid of the record
+
+    Raises:
+        AssertionError: if the term was not found or more than 1 match was found (expected to be unique)
+    """
+    result = conn.query(
+        {"target": target, "filters": {"name": name}, "returnProperties": ["@rid"]},
+        ignore_cache=False,
+    )
+    assert len(result) == 1, f"unable to find unique '{target}' ID for '{name}'"
+
+    return result[0]["@rid"]

--- a/graphkb/vocab.py
+++ b/graphkb/vocab.py
@@ -187,10 +187,8 @@ def get_term_by_name(
 def get_terms_set(
     graphkb_conn: GraphKBConnection, base_terms: Iterable[str], ignore_cache: bool = False
 ) -> Set[str]:
-    """
-    Get a set of terms of vocabulary given some base/parent term names. Returns the record
-    IDs for the resulting terms
-    """
+    """Get a set of vocabulary rids given some base/parent term names."""
+    base_terms = [base_terms] if isinstance(base_terms, str) else base_terms
     cache_key = tuple(sorted(base_terms))
     if graphkb_conn.cache.get(cache_key, None) and not ignore_cache:
         return graphkb_conn.cache[cache_key]

--- a/tests/test_genes.py
+++ b/tests/test_genes.py
@@ -8,14 +8,86 @@ import pytest
 from graphkb import GraphKBConnection
 from graphkb.constants import FUSION_NAMES
 from graphkb.genes import (
+    get_cancer_predisposition_info,
     get_genes_from_variant_types,
     get_oncokb_oncogenes,
     get_oncokb_tumour_supressors,
+    get_pharmacogenomic_info,
+    get_preferred_gene_name,
 )
 
 CANONICAL_ONCOGENES = ['kras', 'nras', 'alk']
 CANONICAL_TS = ['cdkn2a', 'tp53']
 CANONICAL_FUSION_GENES = ['alk', 'ewsr1', 'fli1']
+PHARMACOGENOMIC_INITIAL_GENES = [
+    'ACYP2',
+    'CEP72',
+    # 'CYP26B1',  # defined as hgvsGenomic chr2:g.233760235_233760235nc_000002.12:g.233760235ta[7]>ta[8]
+    'DPYD',
+    'NUDT15',
+    'RARG',
+    'SLC28A3',
+    'TPMT',
+    'UGT1A6',
+]
+CANCER_PREDISP_INITIAL_GENES = [
+    'AKT1',
+    'APC',
+    'ATM',
+    'AXIN2',
+    'BAP1',
+    'BLM',
+    'BMPR1A',
+    'BRCA1',
+    'BRCA2',
+    'BRIP1',
+    'CBL',
+    'CDH1',
+    'CDK4',
+    'CDKN2A',
+    'CHEK2',
+    'DICER1',
+    'EGFR',
+    'EPCAM',
+    'ETV6',
+    'EZH2',
+    'FH',
+    'FLCN',
+    'GATA2',
+    'HRAS',
+    'KIT',
+    'MEN1',
+    'MET',
+    'MLH1',
+    'MSH2',
+    'MSH6',
+    'MUTYH',
+    'NBN',
+    'NF1',
+    'PALB2',
+    'PDGFRA',
+    'PMS2',
+    'PTCH1',
+    'PTEN',
+    'PTPN11',
+    'RAD51C',
+    'RAD51D',
+    'RB1',
+    'RET',
+    'RUNX1',
+    'SDHA',
+    'SDHB',
+    'SDHC',
+    'SDHD',
+    'SMAD4',
+    'SMARCA4',
+    'STK11',
+    'TP53',
+    'TSC1',
+    'TSC2',
+    'VHL',
+    'WT1',
+]
 
 
 @pytest.fixture(scope='module')
@@ -55,6 +127,33 @@ def test_finds_ts(conn, gene):
 
     names = {row['name'] for row in result}
     assert gene in names
+
+
+def test_get_pharmacogenomic_info(conn):
+    genes, matches = get_pharmacogenomic_info(conn)
+    for gene in PHARMACOGENOMIC_INITIAL_GENES:
+        assert gene in genes, f"{gene} not found in get_pharmacogenomic_info"
+        for rid, variant_display in matches.items():
+            if variant_display.startswith(gene):
+                break
+        else:  # no break called
+            assert False, f"No rid found for a pharmacogenomic with {gene}"
+
+
+def test_get_cancer_predisposition_info(conn):
+    genes, matches = get_cancer_predisposition_info(conn)
+    for gene in CANCER_PREDISP_INITIAL_GENES:
+        assert gene in genes, f"{gene} not found in get_cancer_predisposition_info"
+
+
+@pytest.mark.parametrize(
+    'alt_rep', ('NM_033360.4', 'NM_033360', 'ENSG00000133703.11', 'ENSG00000133703')
+)
+def test_get_preferred_gene_name_kras(alt_rep, conn):
+    gene_name = get_preferred_gene_name(conn, alt_rep)
+    assert (
+        'KRAS' == gene_name
+    ), f"Expected KRAS as preferred gene name for {alt_rep}, not '{gene_name}'"
 
 
 @pytest.mark.parametrize('gene', CANONICAL_FUSION_GENES)

--- a/tests/test_match.py
+++ b/tests/test_match.py
@@ -47,6 +47,22 @@ class TestGetEquivalentFeatures:
         assert 'NM_033360.4' in kras
         assert 'ENSG00000133703.11' in kras
 
+    def test_expands_generalizations_kras(self, kras):
+        assert 'NM_033360.4' in kras
+        assert 'NM_033360' in kras
+        assert 'ENSG00000133703.11' in kras
+        assert 'ENSG00000133703' in kras
+
+    @pytest.mark.parametrize(
+        'alt_rep', ('NM_033360.4', 'NM_033360', 'ENSG00000133703.11', 'ENSG00000133703')
+    )
+    def test_expands_generalizations_refseq(self, alt_rep, conn):
+        kras = [f['displayName'] for f in match.get_equivalent_features(conn, alt_rep)]
+        assert 'NM_033360.4' in kras
+        assert 'NM_033360' in kras
+        assert 'ENSG00000133703.11' in kras
+        assert 'ENSG00000133703' in kras
+
 
 class TestMatchCopyVariant:
     def test_bad_category(self, conn):

--- a/tests/test_match.py
+++ b/tests/test_match.py
@@ -63,6 +63,15 @@ class TestGetEquivalentFeatures:
         assert 'ENSG00000133703.11' in kras
         assert 'ENSG00000133703' in kras
 
+    @pytest.mark.parametrize(
+        'alt_rep', ('NM_033360.4', 'NM_033360', 'ENSG00000133703.11', 'ENSG00000133703')
+    )
+    def test_get_preferred_gene_name(self, alt_rep, conn):
+        gene_name = match.get_preferred_gene_name(conn, alt_rep)
+        assert (
+            'KRAS' == gene_name
+        ), f"Expected KRAS as preferred gene name for {alt_rep}, not '{gene_name}'"
+
 
 class TestMatchCopyVariant:
     def test_bad_category(self, conn):

--- a/tests/test_match.py
+++ b/tests/test_match.py
@@ -63,15 +63,6 @@ class TestGetEquivalentFeatures:
         assert 'ENSG00000133703.11' in kras
         assert 'ENSG00000133703' in kras
 
-    @pytest.mark.parametrize(
-        'alt_rep', ('NM_033360.4', 'NM_033360', 'ENSG00000133703.11', 'ENSG00000133703')
-    )
-    def test_get_preferred_gene_name(self, alt_rep, conn):
-        gene_name = match.get_preferred_gene_name(conn, alt_rep)
-        assert (
-            'KRAS' == gene_name
-        ), f"Expected KRAS as preferred gene name for {alt_rep}, not '{gene_name}'"
-
 
 class TestMatchCopyVariant:
     def test_bad_category(self, conn):


### PR DESCRIPTION
Migrate get_cancer_predisposition_info and get_pharmacogenomic_info from gsc_report added to genes.py

These functions use a preferred gene_name to replace transcripts, alternated representations.  Added an equivalent function to genes.py, get_preferred_gene_name.