### PR TITLE
Add support for GeneralizationOf in match

### DIFF
--- a/graphkb/match.py
+++ b/graphkb/match.py
@@ -483,7 +483,7 @@ def match_positional_variant(
                 {
                     'target': convert_to_rid_list(filtered),
                     'queryType': 'similarTo',
-                    'edges': ['AliasOf', 'DeprecatedBy', 'CrossReferenceOf'],
+                    'edges': ['AliasOf', 'DeprecatedBy', 'CrossReferenceOf', 'GeneralizationOf'],
                     'treeEdges': ['Infers'],
                     'returnProperties': POS_VARIANT_RETURN_PROPERTIES,
                 },


### PR DESCRIPTION
Corresponding change in the python adapter to support new GeneralizationOf edges between some generic PositionalVariant and more specific ones, as per [KBDEV-1017](https://www.bcgsc.ca/jira/browse/KBDEV-1017) datafix here: https://svn.bcgsc.ca/bitbucket/projects/DAT/repos/knowledgebase_datafixes/pull-requests/20/overview