### PR TITLE
Bugfix/kbdev 1038 fixing match positional variant urllib2

### DIFF
--- a/graphkb/constants.py
+++ b/graphkb/constants.py
@@ -1,5 +1,7 @@
 import argparse
 
+from typing import Dict
+
 from .types import CategoryBaseTermMapping
 
 DEFAULT_LIMIT = 1000
@@ -137,3 +139,37 @@ INPUT_COPY_CATEGORIES = IterableNamespace(
 INPUT_EXPRESSION_CATEGORIES = IterableNamespace(
     UP='increased expression', DOWN='reduced expression'
 )
+
+# From: https://github.com/bcgsc/pori_graphkb_parser/blob/ae3738842a4c208ab30f58c08ae987594d632504/src/constants.ts#L33-L80
+TYPES_TO_NOTATION: Dict[str, str] = {
+    'acetylation': 'ac',
+    'copy gain': 'copygain',
+    'copy loss': 'copyloss',
+    'deletion': 'del',
+    'duplication': 'dup',
+    'extension': 'ext',
+    'frameshift': 'fs',
+    'fusion': 'fusion',
+    'indel': 'delins',
+    'insertion': 'ins',
+    'inversion': 'inv',
+    'inverted translocation': 'itrans',
+    'methylation': 'me',
+    'missense mutation': 'mis',
+    'mutation': 'mut',
+    'nonsense mutation': '>',
+    'phosphorylation': 'phos',
+    'splice-site': 'spl',
+    'substitution': '>',
+    'translocation': 'trans',
+    'truncating frameshift mutation': 'fs',
+    'ubiquitination': 'ub',
+    # deprecated forms and aliases
+    'frameshift mutation': 'fs',
+    'frameshift truncation': 'fs',
+    'missense variant': 'mis',
+    'truncating frameshift': 'fs',
+    'missense': 'mis',
+    'mutations': 'mut',
+    'nonsense': '>',
+}

--- a/graphkb/match.py
+++ b/graphkb/match.py
@@ -165,6 +165,8 @@ def match_category_variant(
                     ],
                 },
                 'queryType': 'similarTo',
+                'edges': ['AliasOf', 'DeprecatedBy', 'CrossReferenceOf', 'GeneralizationOf'],
+                'treeEdges': ['Infers'],
                 'returnProperties': VARIANT_RETURN_PROPERTIES,
             },
             ignore_cache=ignore_cache,

--- a/graphkb/match.py
+++ b/graphkb/match.py
@@ -266,6 +266,7 @@ def positions_overlap(
 def compare_positional_variants(
     variant: Union[PositionalVariant, ParsedVariant],
     reference_variant: Union[PositionalVariant, ParsedVariant],
+    generic: bool = True,
 ) -> bool:
     """
     Compare 2 variant records from GraphKB to determine if they are equivalent
@@ -273,10 +274,27 @@ def compare_positional_variants(
     Args:
         variant: the input variant
         reference_variant: the reference (matched) variant record
+        generic (bool, optional): also include the more generic variants
 
     Returns:
         bool: True if the records are equivalent
     """
+
+    # If specific vs more-generic variants are not to be considered as equivalent,
+    # check if their stringify representation match and return True or False right away.
+    if not generic:
+        variant_str: str = stringifyVariant(
+            variant,
+            withRef=False,    # Reference(s) will not be included in the string repr.
+            withRefSeq=False, # Reference sequence will not be included in the string repr.
+        )
+        reference_variant_str: str = stringifyVariant(
+            reference_variant,
+            withRef=False,    # Reference(s) will not be included in the string repr.
+            withRefSeq=False, # Reference sequence will not be included in the string repr.
+        )
+        return variant_str == reference_variant_str
+
     if not positions_overlap(
         cast(BasicPosition, variant['break1Start']),
         cast(BasicPosition, reference_variant['break1Start']),

--- a/graphkb/match.py
+++ b/graphkb/match.py
@@ -12,7 +12,13 @@ from .constants import (
     VARIANT_RETURN_PROPERTIES,
 )
 from .types import BasicPosition, Ontology, ParsedVariant, PositionalVariant, Record, Variant
-from .util import FeatureNotFoundError, convert_to_rid_list, logger, looks_like_rid
+from .util import (
+    convert_to_rid_list,
+    FeatureNotFoundError,
+    logger,
+    looks_like_rid,
+    stringifyVariant,
+)
 from .vocab import get_term_tree
 
 FEATURES_CACHE: Set[str] = set()

--- a/graphkb/match.py
+++ b/graphkb/match.py
@@ -510,6 +510,7 @@ def match_positional_variant(
             {'target': 'PositionalVariant', 'filters': query_filters}, ignore_cache=ignore_cache
         ),
     ):
+        # TODO: Check if variant and reference_variant should be interchanged
         if compare_positional_variants(
             variant = parsed,
             reference_variant = cast(PositionalVariant, row),

--- a/graphkb/match.py
+++ b/graphkb/match.py
@@ -593,7 +593,18 @@ def match_positional_variant(
         cat_variant_query(secondary_features, types, None)
 
     # Adding back generic PositionalVariant to the matches
-    matches.extend(filtered_similarAndGeneric)
+    if filtered_similarAndGeneric:
+        matches.extend(
+            conn.query(
+                {
+                    'target': convert_to_rid_list(filtered_similarAndGeneric),
+                    'queryType': 'descendants',
+                    'edges': [],
+                    'returnProperties': POS_VARIANT_RETURN_PROPERTIES,
+                },
+                ignore_cache=ignore_cache,
+            ),
+        )
 
     result: Dict[str, Variant] = {}
     for row in matches:

--- a/graphkb/match.py
+++ b/graphkb/match.py
@@ -285,13 +285,13 @@ def compare_positional_variants(
     if not generic:
         variant_str: str = stringifyVariant(
             variant,
-            withRef=False,    # Reference(s) will not be included in the string repr.
-            withRefSeq=False, # Reference sequence will not be included in the string repr.
+            withRef=False,  # Reference(s) will not be included in the string repr.
+            withRefSeq=False,  # Reference sequence will not be included in the string repr.
         )
         reference_variant_str: str = stringifyVariant(
             reference_variant,
-            withRef=False,    # Reference(s) will not be included in the string repr.
-            withRefSeq=False, # Reference sequence will not be included in the string repr.
+            withRef=False,  # Reference(s) will not be included in the string repr.
+            withRefSeq=False,  # Reference sequence will not be included in the string repr.
         )
         return variant_str == reference_variant_str
 
@@ -501,8 +501,8 @@ def match_positional_variant(
         {'break1Start.@class': parsed['break1Start']['@class']},
     ]
 
-    filtered_similarOnly: List[Record] = [] # For post filter match use
-    filtered_similarAndGeneric: List[Record] = [] # To be added to the matches at the very end
+    filtered_similarOnly: List[Record] = []  # For post filter match use
+    filtered_similarAndGeneric: List[Record] = []  # To be added to the matches at the very end
 
     for row in cast(
         List[Record],
@@ -512,15 +512,15 @@ def match_positional_variant(
     ):
         # TODO: Check if variant and reference_variant should be interchanged
         if compare_positional_variants(
-            variant = parsed,
-            reference_variant = cast(PositionalVariant, row),
-            generic = True,
+            variant=parsed,
+            reference_variant=cast(PositionalVariant, row),
+            generic=True,
         ):
             filtered_similarAndGeneric.append(row)
             if compare_positional_variants(
-                variant = parsed,
-                reference_variant = cast(PositionalVariant, row),
-                generic = False, # Similar variants only
+                variant=parsed,
+                reference_variant=cast(PositionalVariant, row),
+                generic=False,  # Similar variants only
             ):
                 filtered_similarOnly.append(row)
 

--- a/graphkb/match.py
+++ b/graphkb/match.py
@@ -295,6 +295,8 @@ def compare_positional_variants(
         )
         return variant_str == reference_variant_str
 
+    # For break1, check if positions are overlaping between the variant and the reference.
+    # Continue only if True.
     if not positions_overlap(
         cast(BasicPosition, variant['break1Start']),
         cast(BasicPosition, reference_variant['break1Start']),
@@ -304,6 +306,9 @@ def compare_positional_variants(
     ):
         return False
 
+    # For break2, check if positions are overlaping between the variant and the reference.
+    # Continue only if True or no break2.
+    # TODO: check for variant without break2 but reference_variant with one.
     if variant.get('break2Start'):
         if not reference_variant.get('break2Start'):
             return False
@@ -316,6 +321,8 @@ def compare_positional_variants(
         ):
             return False
 
+    # If both variants have untemplated sequence,
+    # check for size and content.
     if (
         variant.get('untemplatedSeq', None) is not None
         and reference_variant.get('untemplatedSeq', None) is not None
@@ -327,6 +334,7 @@ def compare_positional_variants(
             if variant['untemplatedSeqSize'] != reference_variant['untemplatedSeqSize']:
                 return False
 
+        # TODO: Is this 1st conditional necessary?
         if (
             reference_variant['untemplatedSeq'] is not None
             and variant['untemplatedSeq'] is not None
@@ -340,6 +348,8 @@ def compare_positional_variants(
             elif len(variant['untemplatedSeq']) != len(reference_variant['untemplatedSeq']):
                 return False
 
+    # If both variants have a reference sequence,
+    # check if they are the same.
     if (
         variant.get('refSeq', None) is not None
         and reference_variant.get('refSeq', None) is not None
@@ -350,6 +360,7 @@ def compare_positional_variants(
         ):
             if reference_variant['refSeq'].lower() != variant['refSeq'].lower():  # type: ignore
                 return False
+        # TODO: Is this conditional necessary?
         elif len(variant['refSeq']) != len(reference_variant['refSeq']):  # type: ignore
             return False
 

--- a/graphkb/types.py
+++ b/graphkb/types.py
@@ -9,8 +9,8 @@ try:
 except ImportError:
     from typing_extensions import TypedDict
 
-Record: TypedDict = TypedDict('Record', {'@rid': str, '@class': str})
-EmbeddedRecord: TypedDict = TypedDict('EmbeddedRecord', {'@class': str})
+Record: TypedDict = TypedDict("Record", {"@rid": str, "@class": str})
+EmbeddedRecord: TypedDict = TypedDict("EmbeddedRecord", {"@class": str})
 
 RecordLink = Union[str, Record]
 
@@ -21,11 +21,13 @@ class Ontology(Record):
     source: RecordLink
     displayName: str
 
+
 class OntologyTerm(Record):
     name: Optional[str]
     sourceId: Optional[str]
     sourceIdVersion: Optional[str]
     displayName: Optional[str]
+
 
 OntologyLink = Union[str, Ontology]
 

--- a/graphkb/types.py
+++ b/graphkb/types.py
@@ -21,6 +21,11 @@ class Ontology(Record):
     source: RecordLink
     displayName: str
 
+class OntologyTerm(Record):
+    name: Optional[str]
+    sourceId: Optional[str]
+    sourceIdVersion: Optional[str]
+    displayName: Optional[str]
 
 OntologyLink = Union[str, Ontology]
 

--- a/graphkb/util.py
+++ b/graphkb/util.py
@@ -339,6 +339,7 @@ def get_rid(conn: GraphKBConnection, target: str, name: str) -> str:
 
     return result[0]["@rid"]
 
+
 def ontologyTermRepr(term: Union[OntologyTerm, str]) -> str:
     if type(term) is not str:
         if getattr(term, 'displayName', None) and term.displayName != '':
@@ -350,12 +351,14 @@ def ontologyTermRepr(term: Union[OntologyTerm, str]) -> str:
         return ''
     return term
 
+
 def stripParentheses(breakRepr: str) -> str:
     match = re.search(r"^([a-z])\.\((.+)\)$", breakRepr)
 
     if match:
         return f"{match.group(1)}.{match.group(2)}"
     return breakRepr
+
 
 def stripRefSeq(breakRepr: str) -> str:
     match = re.search(r"^([a-z])\.[A-Z]*([0-9]*[A-Z]*)$", breakRepr)
@@ -364,12 +367,12 @@ def stripRefSeq(breakRepr: str) -> str:
         return f"{match.group(1)}.{match.group(2)}"
     return breakRepr
 
+
 def stripDisplayName(
     displayName: str,
     withRef: bool = True,
     withRefSeq: bool = True,
 ) -> str:
-
     match: object = re.search(r"^(.*)(\:)(.*)$", displayName)
     if match and not withRef:
         if withRefSeq:
@@ -397,6 +400,7 @@ def stripDisplayName(
         displayName = ref + prefix + rest
 
     return displayName
+
 
 def stringifyVariant(
     variant: Union[PositionalVariant, ParsedVariant],
@@ -428,7 +432,6 @@ def stringifyVariant(
     # then strip unwanted features, than return it right away
     if displayName != '':
         return stripDisplayName(displayName, withRef, withRefSeq)
-
 
     # If variant is a ParsedVariant (i.e. variant without a displayName yet),
     # the following will return a stringify representation (displayName/hgvs) of that variant
@@ -466,9 +469,7 @@ def stringifyVariant(
         if withRefSeq:
             break1Repr_noParentheses = stripParentheses(break1Repr)
             break2Repr_noParentheses = stripParentheses(break2Repr)
-            result.append(
-                f"({break1Repr_noParentheses},{break2Repr_noParentheses})"
-            )
+            result.append(f"({break1Repr_noParentheses},{break2Repr_noParentheses})")
         else:
             break1Repr_noParentheses_noRefSeq = stripRefSeq(stripParentheses(break1Repr))
             break2Repr_noParentheses_noRefSeq = stripRefSeq(stripParentheses(break2Repr))
@@ -480,7 +481,6 @@ def stringifyVariant(
         elif untemplatedSeqSize:
             result.append(str(untemplatedSeqSize))
         return ''.join(result)
-
 
     # Continuous notation...
 
@@ -497,12 +497,10 @@ def stringifyVariant(
         result.append(stripRefSeq(break1Repr))
         if break2Repr != '':
             result.append(f"_{stripRefSeq(break2Repr)[2:]}")
-    
 
     # refSeq, truncation, notationType, untemplatedSeq, untemplatedSeqSize
     if any(i in notationType for i in ['ext', 'fs']) or (
-        notationType == '>'
-        and break1Repr.startswith('p.')
+        notationType == '>' and break1Repr.startswith('p.')
     ):
         result.append(untemplatedSeq)
     if notationType == 'mis' and break1Repr.startswith('p.'):
@@ -523,7 +521,7 @@ def stringifyVariant(
         if any(i in notationType for i in ['dup', 'del', 'inv']):
             if withRefSeq:
                 result.append(refSeq)
-        if any(i in notationType for i in ['ins', 'delins']): 
+        if any(i in notationType for i in ['ins', 'delins']):
             if untemplatedSeq != '':
                 result.append(untemplatedSeq)
             elif untemplatedSeqSize:

--- a/graphkb/util.py
+++ b/graphkb/util.py
@@ -361,10 +361,13 @@ def stripParentheses(breakRepr: str) -> str:
 
 
 def stripRefSeq(breakRepr: str) -> str:
-    match = re.search(r"^([a-z])\.[A-Z]*([0-9]*[A-Z]*)$", breakRepr)
-
+    # 1 leading RefSeq
+    match = re.search(r"^([a-z])\.([A-Z]*|\?)([0-9]*[A-Z]*)$", breakRepr)
     if match:
-        return f"{match.group(1)}.{match.group(2)}"
+        return f"{match.group(1)}.{match.group(3)}"
+
+    # TODO: Deal with cases like "p.?889_?890"
+
     return breakRepr
 
 

--- a/graphkb/util.py
+++ b/graphkb/util.py
@@ -366,7 +366,7 @@ def stripRefSeq(breakRepr: str) -> str:
     if match:
         return f"{match.group(1)}.{match.group(3)}"
 
-    # TODO: Deal with cases like "p.?889_?890"
+    # TODO: Deal with cases like "p.?889_?890", "chr4:g.55593604_55593605delGGinsTT", ...
 
     return breakRepr
 
@@ -402,6 +402,9 @@ def stripDisplayName(
 
         displayName = ref + prefix + rest
 
+    # TODO: Deal with more complex cases like fusion, cds with offset (ex. 'VHL:c.464-2G>A')
+    # and other complex cases (ex. 'VHL:c.330_331delCAinsTT')
+
     return displayName
 
 
@@ -432,7 +435,7 @@ def stringifyVariant(
 
     # If variant is a PositionalVariant (i.e. variant with a displayName) and
     # we DO NOT have the appropriate string representation,
-    # then strip unwanted features, than return it right away
+    # then strip unwanted features, then return it right away
     if displayName != '':
         return stripDisplayName(displayName, withRef, withRefSeq)
 
@@ -536,5 +539,7 @@ def stringifyVariant(
             refSeq = ''
         untemplatedSeq = untemplatedSeq if untemplatedSeq != '' else '?'
         result.append(f"{refSeq}{notationType}{untemplatedSeq}")
+
+    # TODO: Deal with more complexes cases like 'MED12:p.(?34_?68)mut'
 
     return ''.join(result)

--- a/setup.cfg
+++ b/setup.cfg
@@ -22,7 +22,7 @@ python_requires = >=3.6
 dependency_links = []
 include_package_data = True
 install_requires =
-    requests>=2.22.0,<3
+    requests<2.29.0
     typing_extensions>=3.7.4.2,<4.4
 
 [options.extras_require]

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -2,7 +2,8 @@ import pytest
 import os
 from graphkb import util, GraphKBConnection
 
-class OntologyTerm():
+
+class OntologyTerm:
     def __init__(self, name, sourceId, displayName):
         self.name = name
         self.sourceId = sourceId
@@ -57,15 +58,16 @@ class TestOntologyTermRepr:
     @pytest.mark.parametrize(
         'termObjOpt,termRepr',
         [
-            [{"displayName": 'abc123', "name": '', "sourceId": ''}, 'abc123' ],
-            [{"displayName": '', "name": '', "sourceId": 'abc123'}, 'abc123' ],
-            [{"displayName": '', "name": 'abc123', "sourceId": ''}, 'abc123' ],
+            [{"displayName": 'abc123', "name": '', "sourceId": ''}, 'abc123'],
+            [{"displayName": '', "name": '', "sourceId": 'abc123'}, 'abc123'],
+            [{"displayName": '', "name": 'abc123', "sourceId": ''}, 'abc123'],
             [{"displayName": '', "name": '', "sourceId": ''}, ''],
         ],
     )
     def test_ontologyTermRepr_obj(self, termObjOpt, termRepr):
         termObj = OntologyTerm(**termObjOpt)
         assert util.ontologyTermRepr(termObj) == termRepr
+
 
 class TestStripParentheses:
     @pytest.mark.parametrize(
@@ -79,6 +81,7 @@ class TestStripParentheses:
     )
     def test_stripParentheses(self, breakRepr, StrippedBreakRepr):
         assert util.stripParentheses(breakRepr) == StrippedBreakRepr
+
 
 class TestStripRefSeq:
     @pytest.mark.parametrize(
@@ -101,9 +104,26 @@ class TestStripDisplayName:
             [{'displayName': 'ABL1:p.T315I', 'withRef': False, 'withRefSeq': True}, 'p.T315I'],
             [{'displayName': 'ABL1:p.T315I', 'withRef': True, 'withRefSeq': False}, 'ABL1:p.315I'],
             [{'displayName': 'ABL1:p.T315I', 'withRef': False, 'withRefSeq': False}, 'p.315I'],
-            [{'displayName': 'chr3:g.41266125C>T', 'withRef': False, 'withRefSeq': False}, 'g.41266125>T'],
-            [{'displayName': 'chrX:g.99662504_99662505insG', 'withRef': False, 'withRefSeq': False}, 'g.99662504_99662505insG'],
-            [{'displayName': 'chrX:g.99662504_99662505dup', 'withRef': False, 'withRefSeq': False}, 'g.99662504_99662505dup'],
+            [
+                {'displayName': 'chr3:g.41266125C>T', 'withRef': False, 'withRefSeq': False},
+                'g.41266125>T',
+            ],
+            [
+                {
+                    'displayName': 'chrX:g.99662504_99662505insG',
+                    'withRef': False,
+                    'withRefSeq': False,
+                },
+                'g.99662504_99662505insG',
+            ],
+            [
+                {
+                    'displayName': 'chrX:g.99662504_99662505dup',
+                    'withRef': False,
+                    'withRefSeq': False,
+                },
+                'g.99662504_99662505dup',
+            ],
             # TODO: [{'displayName': 'VHL:c.330_331delCAinsTT', 'withRef': False, 'withRefSeq': False}, 'c.330_331delinsTT'],
             # TODO: [{'displayName': 'VHL:c.464-2G>A', 'withRef': False, 'withRefSeq': False}, 'c.464-2>A'],
         ],
@@ -120,7 +140,11 @@ class TestStringifyVariant:
             ['VHL:c.345C>G', {'withRef': False, 'withRefSeq': True}, 'c.345C>G'],
             ['VHL:c.345C>G', {'withRef': True, 'withRefSeq': False}, 'VHL:c.345>G'],
             ['VHL:c.345C>G', {'withRef': False, 'withRefSeq': False}, 'c.345>G'],
-            ['(LMNA,NTRK1):fusion(e.10,e.12)', {'withRef': False, 'withRefSeq': False}, 'fusion(e.10,e.12)'],
+            [
+                '(LMNA,NTRK1):fusion(e.10,e.12)',
+                {'withRef': False, 'withRefSeq': False},
+                'fusion(e.10,e.12)',
+            ],
             ['ABCA12:p.N1671Ifs*4', {'withRef': False, 'withRefSeq': False}, 'p.1671Ifs*4'],
             ['x:y.p22.33copyloss', {'withRef': False, 'withRefSeq': False}, 'y.p22.33copyloss'],
             # TODO: ['MED12:p.(?34_?68)mut', {'withRef': False, 'withRefSeq': False}, 'p.(34_68)mut'],
@@ -141,7 +165,7 @@ class TestStringifyVariant:
             ['#158:35317', 1652734056311, 'c.1>G'],
         ],
     )
-    def test_stringifyVariant_positional(self, conn, rid,createdAt,stringifiedVariant):
+    def test_stringifyVariant_positional(self, conn, rid, createdAt, stringifiedVariant):
         opt = {'withRef': False, 'withRefSeq': False}
         variant = conn.get_record_by_id(rid)
         if variant and variant.get('createdAt', None) == createdAt:

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,6 +1,19 @@
 import pytest
+import os
+from graphkb import util, GraphKBConnection
 
-from graphkb import util
+class OntologyTerm():
+    def __init__(self, name, sourceId, displayName):
+        self.name = name
+        self.sourceId = sourceId
+        self.displayName = displayName
+
+
+@pytest.fixture(scope='module')
+def conn() -> GraphKBConnection:
+    conn = GraphKBConnection()
+    conn.login(os.environ['GRAPHKB_USER'], os.environ['GRAPHKB_PASS'])
+    return conn
 
 
 class TestLooksLikeRid:
@@ -28,3 +41,108 @@ class TestLooksLikeRid:
 )
 def test_convert_aa_3to1(input, result):
     assert util.convert_aa_3to1(input) == result
+
+
+class TestOntologyTermRepr:
+    @pytest.mark.parametrize(
+        'termStr,termRepr',
+        [
+            ['missense mutation', 'missense mutation'],
+            ['', ''],
+        ],
+    )
+    def test_ontologyTermRepr_str(self, termStr, termRepr):
+        assert util.ontologyTermRepr(termStr) == termRepr
+
+    @pytest.mark.parametrize(
+        'termObjOpt,termRepr',
+        [
+            [{"displayName": 'abc123', "name": '', "sourceId": ''}, 'abc123' ],
+            [{"displayName": '', "name": '', "sourceId": 'abc123'}, 'abc123' ],
+            [{"displayName": '', "name": 'abc123', "sourceId": ''}, 'abc123' ],
+            [{"displayName": '', "name": '', "sourceId": ''}, ''],
+        ],
+    )
+    def test_ontologyTermRepr_obj(self, termObjOpt, termRepr):
+        termObj = OntologyTerm(**termObjOpt)
+        assert util.ontologyTermRepr(termObj) == termRepr
+
+class TestStripParentheses:
+    @pytest.mark.parametrize(
+        'breakRepr,StrippedBreakRepr',
+        [
+            ['p.(E2015_Q2114)', 'p.E2015_Q2114'],
+            ['p.(?572_?630)', 'p.?572_?630'],
+            ['g.178916854', 'g.178916854'],
+            ['e.10', 'e.10'],
+        ],
+    )
+    def test_stripParentheses(self, breakRepr, StrippedBreakRepr):
+        assert util.stripParentheses(breakRepr) == StrippedBreakRepr
+
+class TestStripRefSeq:
+    @pytest.mark.parametrize(
+        'breakRepr,StrippedBreakRepr',
+        [
+            ['p.L2209', 'p.2209'],
+            ['p.?891', 'p.891'],
+            # TODO: ['p.?572_?630', 'p.572_630'],
+        ],
+    )
+    def test_stripRefSeq(self, breakRepr, StrippedBreakRepr):
+        assert util.stripRefSeq(breakRepr) == StrippedBreakRepr
+
+
+class TestStripDisplayName:
+    @pytest.mark.parametrize(
+        'opt,stripDisplayName',
+        [
+            [{'displayName': 'ABL1:p.T315I', 'withRef': True, 'withRefSeq': True}, 'ABL1:p.T315I'],
+            [{'displayName': 'ABL1:p.T315I', 'withRef': False, 'withRefSeq': True}, 'p.T315I'],
+            [{'displayName': 'ABL1:p.T315I', 'withRef': True, 'withRefSeq': False}, 'ABL1:p.315I'],
+            [{'displayName': 'ABL1:p.T315I', 'withRef': False, 'withRefSeq': False}, 'p.315I'],
+            [{'displayName': 'chr3:g.41266125C>T', 'withRef': False, 'withRefSeq': False}, 'g.41266125>T'],
+            [{'displayName': 'chrX:g.99662504_99662505insG', 'withRef': False, 'withRefSeq': False}, 'g.99662504_99662505insG'],
+            [{'displayName': 'chrX:g.99662504_99662505dup', 'withRef': False, 'withRefSeq': False}, 'g.99662504_99662505dup'],
+            # TODO: [{'displayName': 'VHL:c.330_331delCAinsTT', 'withRef': False, 'withRefSeq': False}, 'c.330_331delinsTT'],
+            # TODO: [{'displayName': 'VHL:c.464-2G>A', 'withRef': False, 'withRefSeq': False}, 'c.464-2>A'],
+        ],
+    )
+    def test_stripDisplayName(self, opt, stripDisplayName):
+        assert util.stripDisplayName(**opt) == stripDisplayName
+
+
+class TestStringifyVariant:
+    @pytest.mark.parametrize(
+        'hgvs_string,opt,stringifiedVariant',
+        [
+            ['VHL:c.345C>G', {'withRef': True, 'withRefSeq': True}, 'VHL:c.345C>G'],
+            ['VHL:c.345C>G', {'withRef': False, 'withRefSeq': True}, 'c.345C>G'],
+            ['VHL:c.345C>G', {'withRef': True, 'withRefSeq': False}, 'VHL:c.345>G'],
+            ['VHL:c.345C>G', {'withRef': False, 'withRefSeq': False}, 'c.345>G'],
+            ['(LMNA,NTRK1):fusion(e.10,e.12)', {'withRef': False, 'withRefSeq': False}, 'fusion(e.10,e.12)'],
+            ['ABCA12:p.N1671Ifs*4', {'withRef': False, 'withRefSeq': False}, 'p.1671Ifs*4'],
+            ['x:y.p22.33copyloss', {'withRef': False, 'withRefSeq': False}, 'y.p22.33copyloss'],
+            # TODO: ['MED12:p.(?34_?68)mut', {'withRef': False, 'withRefSeq': False}, 'p.(34_68)mut'],
+            # TODO: ['FLT3:p.(?572_?630)_(?572_?630)ins', {'withRef': False, 'withRefSeq': False}, 'p.(572_630)_(572_630)ins'],
+        ],
+    )
+    def test_stringifyVariant_parsed(self, conn, hgvs_string, opt, stringifiedVariant):
+        opt['variant'] = conn.parse(hgvs_string)
+        assert util.stringifyVariant(**opt) == stringifiedVariant
+
+    # Based on the assumption that these variants are in the database.
+    # createdAt date help avoiding errors if assumption tuns to be false
+    @pytest.mark.parametrize(
+        'rid,createdAt,stringifiedVariant',
+        [
+            ['#157:0', 1565627324397, 'p.315I'],
+            ['#157:79', 1565627683602, 'p.776_777insVGC'],
+            ['#158:35317', 1652734056311, 'c.1>G'],
+        ],
+    )
+    def test_stringifyVariant_positional(self, conn, rid,createdAt,stringifiedVariant):
+        opt = {'withRef': False, 'withRefSeq': False}
+        variant = conn.get_record_by_id(rid)
+        if variant and variant.get('createdAt', None) == createdAt:
+            assert util.stringifyVariant(variant=variant, **opt) == stringifiedVariant


### PR DESCRIPTION
This PR is related, at least in part, to at least all these issues:
- [KBDEV-1024](https://www.bcgsc.ca/jira/browse/KBDEV-1024) - hgvsCds inappropriately matching missense to nonsense mutation
- [KBDEV-1029](https://www.bcgsc.ca/jira/browse/KBDEV-1029) - Replace GeneralizationOf edges by Infers edges
- [KBDEV-1038](https://www.bcgsc.ca/jira/browse/KBDEV-1038) - POG1370 FGFR4 p. N535K shown matched to p. N535D of GraphKB
- [DEVSU-1980](https://www.bcgsc.ca/jira/browse/DEVSU-1980) - rapid report filter fixes

The most important change affect the match_positional_variant() fnc behavior, where filtering the list of potential positional variants with the compare_positional_variants() fcn is done twice, the second time keeping only equivalent variants without the more generic ones (ex. KRAS:p.G12D without KRAS:p.G12X). This allows further 'similarTo' queries to the API to return the appropriate variants following Infers edges, now that they have been transfered from SIMILARITY_EDGES to TREE_EDGES array since https://github.com/bcgsc/pori_graphkb_api/pull/57.

Include a fix to the request package version to ensure urllib compatibility.