### PR TITLE
Update GH workflow for PyPi publishing on released, #2

### DIFF
--- a/.github/workflows/pypipublish.yml
+++ b/.github/workflows/pypipublish.yml
@@ -5,7 +5,7 @@ name: upload to pypi
 
 on:
   release:
-    types: [created]
+    types: [released]
 
 jobs:
   deploy:

--- a/.github/workflows/pypipublish.yml
+++ b/.github/workflows/pypipublish.yml
@@ -6,6 +6,7 @@ name: upload to pypi
 on:
   release:
     types: [released]
+  workflow_dispatch:
 
 jobs:
   deploy:

--- a/setup.cfg
+++ b/setup.cfg
@@ -10,7 +10,7 @@ include_trailing_comma = true
 [metadata]
 name = graphkb
 url = https://github.com/bcgsc/pori_graphkb_python
-version = 1.10.0
+version = 1.10.1
 author_email = graphkb@bcgsc.ca
 description = python adapter for interacting with the GraphKB API
 long_description = file: README.md


### PR DESCRIPTION
from https://github.com/bcgsc/pori_graphkb_python/pull/86
this time by branching out of master and bumping the version number.