### PR TITLE
Bugfix/kbdev 1044 substitution mismatched to nonsense

### DIFF
--- a/graphkb/match.py
+++ b/graphkb/match.py
@@ -431,7 +431,11 @@ def match_positional_variant(
         gene1 = parsed['reference1']
 
     gene1_features = get_equivalent_features(
-        conn, gene1, source=gene_source, is_source_id=gene_is_source_id, ignore_cache=ignore_cache,
+        conn,
+        gene1,
+        source=gene_source,
+        is_source_id=gene_is_source_id,
+        ignore_cache=ignore_cache,
     )
     features = convert_to_rid_list(gene1_features)
 
@@ -492,7 +496,9 @@ def match_positional_variant(
     ):
         # TODO: Check if variant and reference_variant should be interchanged
         if compare_positional_variants(
-            variant=parsed, reference_variant=cast(PositionalVariant, row), generic=True,
+            variant=parsed,
+            reference_variant=cast(PositionalVariant, row),
+            generic=True,
         ):
             filtered_similarAndGeneric.append(row)
             if compare_positional_variants(

--- a/graphkb/match.py
+++ b/graphkb/match.py
@@ -431,11 +431,7 @@ def match_positional_variant(
         gene1 = parsed['reference1']
 
     gene1_features = get_equivalent_features(
-        conn,
-        gene1,
-        source=gene_source,
-        is_source_id=gene_is_source_id,
-        ignore_cache=ignore_cache,
+        conn, gene1, source=gene_source, is_source_id=gene_is_source_id, ignore_cache=ignore_cache,
     )
     features = convert_to_rid_list(gene1_features)
 
@@ -496,9 +492,7 @@ def match_positional_variant(
     ):
         # TODO: Check if variant and reference_variant should be interchanged
         if compare_positional_variants(
-            variant=parsed,
-            reference_variant=cast(PositionalVariant, row),
-            generic=True,
+            variant=parsed, reference_variant=cast(PositionalVariant, row), generic=True,
         ):
             filtered_similarAndGeneric.append(row)
             if compare_positional_variants(
@@ -533,7 +527,7 @@ def match_positional_variant(
     )
 
     types = convert_to_rid_list(variant_types_details)
-    
+
     matches.extend(
         conn.query(
             {

--- a/graphkb/match.py
+++ b/graphkb/match.py
@@ -531,7 +531,7 @@ def match_positional_variant(
         root_exclude_term='mutation' if secondary_features else '',
         ignore_cache=ignore_cache,
     )
-    
+
     types = convert_to_rid_list(variant_types_details)
 
     if not types:

--- a/graphkb/match.py
+++ b/graphkb/match.py
@@ -533,11 +533,7 @@ def match_positional_variant(
     )
 
     types = convert_to_rid_list(variant_types_details)
-
-    if not types:
-        variant_type = parsed['type']
-        raise ValueError(f'unable to find the term/category ({variant_type}) or any equivalent')
-
+    
     matches.extend(
         conn.query(
             {

--- a/tests/test_match.py
+++ b/tests/test_match.py
@@ -460,7 +460,6 @@ class TestMatchPositionalVariant:
         # GERO-303 - technically this format is incorrect.
         assert match.match_positional_variant(conn, 'TERT:c.1-124C>T')
 
-    @pytest.mark.skipif(True, reason="TODO: GERO-299 incomplete; cds and genomic fail test.")
     def test_missense_is_not_nonsense(self, conn):
         """GERO-299 - nonsense mutation creates a stop codon and is usually more severe."""
         # equivalent TP53 notations


### PR DESCRIPTION
In match.py::match_positional_variant(),
we now use only equivalent terms in lieu of whole tree for list of matching types.
We also remove type filtering for first positional variant matching query since it was unnecessary.

Fix GERO-299 and KBDEV-1044.