### PR TITLE
Bugfix/kbdev 1115 get cancer genes

### DIFF
--- a/graphkb/constants.py
+++ b/graphkb/constants.py
@@ -60,8 +60,10 @@ STATEMENT_RETURN_PROPERTIES = (
 
 
 ONCOKB_SOURCE_NAME = "oncokb"
+TSO500_SOURCE_NAME = "tso500"
 ONCOGENE = "oncogenic"
 TUMOUR_SUPPRESSIVE = "tumour suppressive"
+CANCER_GENE = "cancer gene"
 FUSION_NAMES = ["structural variant", "fusion"]
 
 PHARMACOGENOMIC_SOURCE_EXCLUDE_LIST = ["cancer genome interpreter", "civic"]

--- a/graphkb/genes.py
+++ b/graphkb/genes.py
@@ -4,6 +4,7 @@ from typing import Any, Dict, List, Sequence, Set, Tuple, cast
 from . import GraphKBConnection
 from .constants import (
     BASE_THERAPEUTIC_TERMS,
+    CANCER_GENE,
     CHROMOSOMES,
     FAILED_REVIEW_STATUS,
     GENE_RETURN_PROPERTIES,
@@ -12,6 +13,7 @@ from .constants import (
     PHARMACOGENOMIC_SOURCE_EXCLUDE_LIST,
     PREFERRED_GENE_SOURCE,
     RELEVANCE_BASE_TERMS,
+    TSO500_SOURCE_NAME,
     TUMOUR_SUPPRESSIVE,
 )
 from .match import get_equivalent_features
@@ -76,6 +78,18 @@ def get_oncokb_tumour_supressors(conn: GraphKBConnection) -> List[Ontology]:
         gene (Feature) records
     """
     return _get_tumourigenesis_genes_list(conn, TUMOUR_SUPPRESSIVE, [ONCOKB_SOURCE_NAME])
+
+
+def get_cancer_genes(conn: GraphKBConnection) -> List[Ontology]:
+    """Get the list of cancer genes stored in GraphKB derived from OncoKB & TSO500.
+
+    Args:
+        conn: the graphkb connection object
+
+    Returns:
+        gene (Feature) records
+    """
+    return _get_tumourigenesis_genes_list(conn, CANCER_GENE, [ONCOKB_SOURCE_NAME, TSO500_SOURCE_NAME])
 
 
 def get_therapeutic_associated_genes(graphkb_conn: GraphKBConnection) -> List[Ontology]:

--- a/graphkb/genes.py
+++ b/graphkb/genes.py
@@ -28,7 +28,6 @@ def _get_tumourigenesis_genes_list(
     sources: List[str],
     ignore_cache: bool = False,
 ) -> List[Ontology]:
-
     statements = cast(
         List[Statement],
         conn.query(
@@ -37,13 +36,13 @@ def _get_tumourigenesis_genes_list(
                 "filters": {
                     "AND": [
                         {"source": {"target": "Source", "filters": {"name": sources}}},
-                        {"relevance": {"target": "Vocabulary", "filters": {"name": relevance}}}
+                        {"relevance": {"target": "Vocabulary", "filters": {"name": relevance}}},
                     ]
                 },
                 "returnProperties": [f"subject.{prop}" for prop in GENE_RETURN_PROPERTIES],
             },
             ignore_cache=ignore_cache,
-        )
+        ),
     )
 
     genes: Dict[str, Ontology] = {}
@@ -89,7 +88,9 @@ def get_cancer_genes(conn: GraphKBConnection) -> List[Ontology]:
     Returns:
         gene (Feature) records
     """
-    return _get_tumourigenesis_genes_list(conn, CANCER_GENE, [ONCOKB_SOURCE_NAME, TSO500_SOURCE_NAME])
+    return _get_tumourigenesis_genes_list(
+        conn, CANCER_GENE, [ONCOKB_SOURCE_NAME, TSO500_SOURCE_NAME]
+    )
 
 
 def get_therapeutic_associated_genes(graphkb_conn: GraphKBConnection) -> List[Ontology]:

--- a/tests/test_genes.py
+++ b/tests/test_genes.py
@@ -7,6 +7,7 @@ import pytest
 
 from graphkb import GraphKBConnection
 from graphkb.genes import (
+    get_cancer_genes,
     get_cancer_predisposition_info,
     get_gene_information,
     get_genes_from_variant_types,
@@ -22,6 +23,7 @@ EXCLUDE_INTEGRATION_TESTS = os.environ.get("EXCLUDE_INTEGRATION_TESTS") == "1"
 
 CANONICAL_ONCOGENES = ["kras", "nras", "alk"]
 CANONICAL_TS = ["cdkn2a", "tp53"]
+CANONICAL_CG = ["ercc1", "fanci", "h2bc4", "h2bc17", "acvr1b"]
 CANONICAL_FUSION_GENES = ["alk", "ewsr1", "fli1"]
 CANONICAL_STRUCTURAL_VARIANT_GENES = ["brca1", "dpyd", "pten"]
 CANNONICAL_THERAPY_GENES = ["erbb2", "brca2", "egfr"]
@@ -112,6 +114,8 @@ def test_oncogene(conn):
         assert gene in names
     for gene in CANONICAL_TS:
         assert gene not in names
+    for gene in CANONICAL_CG:
+        assert gene not in names
 
 
 def test_tumour_supressors(conn):
@@ -119,6 +123,19 @@ def test_tumour_supressors(conn):
     names = {row["name"] for row in result}
     for gene in CANONICAL_TS:
         assert gene in names
+    for gene in CANONICAL_ONCOGENES:
+        assert gene not in names
+    for gene in CANONICAL_CG:
+        assert gene not in names
+
+
+def test_cancer_genes(conn):
+    result = get_cancer_genes(conn)
+    names = {row["name"] for row in result}
+    for gene in CANONICAL_CG:
+        assert gene in names
+    for gene in CANONICAL_TS:
+        assert gene not in names
     for gene in CANONICAL_ONCOGENES:
         assert gene not in names
 


### PR DESCRIPTION
As per [DEVSU-2032](https://www.bcgsc.ca/jira/browse/DEVSU-2032)/[DEVSU-2038](https://www.bcgsc.ca/jira/browse/DEVSU-2038) requirements.

Following datafix [KBDEV-1084](https://www.bcgsc.ca/jira/browse/KBDEV-1084).

- Add a get_cancer_genes() function to retreive list of all unique genes with a 'cancer gene' statement.
- Refeactor get_oncokb_gene_list() into get_tumourigenesis_genes_list() allowing for a more generic usage