### PR TITLE
Bugfix/kbdev 1133 incorrect matching

### DIFF
--- a/graphkb/constants.py
+++ b/graphkb/constants.py
@@ -176,7 +176,6 @@ TYPES_TO_NOTATION: Dict[str, str] = {
 }
 
 # For match.type_screening() [KBDEV-1056]
-DEFAULT_NON_STRUCTURAL_VARIANT_TYPE = 'mutation'
 STRUCTURAL_VARIANT_SIZE_THRESHOLD = 48  # bp
 STRUCTURAL_VARIANT_TYPES = [
     "structural variant",

--- a/graphkb/constants.py
+++ b/graphkb/constants.py
@@ -177,6 +177,10 @@ TYPES_TO_NOTATION: Dict[str, str] = {
 
 # For match.type_screening() [KBDEV-1056]
 STRUCTURAL_VARIANT_SIZE_THRESHOLD = 48  # bp
+STRUCTURAL_VARIANT_ALIASES = [
+    "structural variant",
+    "rearrangement",
+]
 STRUCTURAL_VARIANT_TYPES = [
     "structural variant",
     "insertion",

--- a/graphkb/match.py
+++ b/graphkb/match.py
@@ -570,11 +570,27 @@ def match_positional_variant(
                 f"unable to find the gene ({gene2}) or any equivalent representations"
             )
 
+    # TYPE
+    # screening type for discrepancies regarding structural variants
+    screened_type = type_screening(conn, parsed, updateStructuralTypes)
+
+    # disambiguate the variant type
+    variant_types_details = get_equivalent_terms(
+        conn,
+        screened_type,
+        root_exclude_term="mutation" if secondary_features else "",
+        ignore_cache=ignore_cache,
+    )
+    types = convert_to_rid_list(variant_types_details)
+
+
+    # MATCHING POSITIONAL VARIANT, REGARDLESS OF POSITIONS
     # match the existing mutations (positional)
     query_filters = [
         {"reference1": features},
         {"reference2": secondary_features},
         {"break1Start.@class": parsed["break1Start"]["@class"]},
+        {"type": types},
     ]
 
     filtered_similarOnly: List[Record] = []  # For post filter match use
@@ -616,18 +632,6 @@ def match_positional_variant(
             )
         )
 
-    # screening type for discrepancies regarding structural variants
-    screened_type = type_screening(conn, parsed, updateStructuralTypes)
-
-    # disambiguate the variant type
-    variant_types_details = get_equivalent_terms(
-        conn,
-        screened_type,
-        root_exclude_term="mutation" if secondary_features else "",
-        ignore_cache=ignore_cache,
-    )
-
-    types = convert_to_rid_list(variant_types_details)
 
     matches.extend(
         conn.query(

--- a/graphkb/match.py
+++ b/graphkb/match.py
@@ -580,6 +580,7 @@ def match_positional_variant(
     filtered_similarOnly: List[Record] = []  # For post filter match use
     filtered_similarAndGeneric: List[Record] = []  # To be added to the matches at the very end
 
+    # FILTERING OUT MISMATCHED POSITIONS
     for row in cast(
         List[Record],
         conn.query(
@@ -587,7 +588,9 @@ def match_positional_variant(
         ),
     ):
         if compare_positional_variants(
-            reference_variant=parsed, variant=cast(PositionalVariant, row), generic=True
+            reference_variant=parsed,
+            variant=cast(PositionalVariant, row),
+            generic=True,
         ):
             filtered_similarAndGeneric.append(row)
             if compare_positional_variants(

--- a/graphkb/match.py
+++ b/graphkb/match.py
@@ -585,8 +585,8 @@ def match_positional_variant(
             get_equivalent_terms(conn, 'structural variant', 'mutation'),
         ) if updateStructuralTypes else STRUCTURAL_VARIANT_ALIASES
         # remove potential structural type aliases
-        variant_types_details = filter(lambda x: False if x['name'] in structural_types else True, variant_types_details)
-    
+        variant_types_details = list(filter(lambda x: False if x['name'] in structural_types else True, variant_types_details))
+
     # convert to RIDs
     types = convert_to_rid_list(variant_types_details)
 

--- a/graphkb/match.py
+++ b/graphkb/match.py
@@ -311,7 +311,6 @@ def compare_positional_variants(
 
     # For break2, check if positions are overlaping between the variant and the reference.
     # Continue only if True or no break2.
-    # TODO: check for variant without break2 but reference_variant with one.
     if reference_variant.get("break2Start"):
         if not variant.get("break2Start"):
             return False

--- a/graphkb/match.py
+++ b/graphkb/match.py
@@ -303,9 +303,7 @@ def compare_positional_variants(
     if not positions_overlap(
         cast(BasicPosition, reference_variant["break1Start"]),
         cast(BasicPosition, variant["break1Start"]),
-        None
-        if "break1End" not in variant
-        else cast(BasicPosition, variant["break1End"]),
+        None if "break1End" not in variant else cast(BasicPosition, variant["break1End"]),
     ):
         return False
 
@@ -317,9 +315,7 @@ def compare_positional_variants(
         if not positions_overlap(
             cast(BasicPosition, reference_variant["break2Start"]),
             cast(BasicPosition, variant["break2Start"]),
-            None
-            if "break2End" not in variant
-            else cast(BasicPosition, variant["break2End"]),
+            None if "break2End" not in variant else cast(BasicPosition, variant["break2End"]),
         ):
             return False
 
@@ -580,16 +576,23 @@ def match_positional_variant(
     # screening type for discrepancies regarding structural variants
     if not structural_type_screening(conn, parsed, updateStructuralTypes):
         # get structural type aliases
-        structural_types = map(
-            lambda x: x['name'],
-            get_equivalent_terms(conn, 'structural variant', 'mutation'),
-        ) if updateStructuralTypes else STRUCTURAL_VARIANT_ALIASES
+        structural_types = (
+            map(
+                lambda x: x['name'],
+                get_equivalent_terms(conn, 'structural variant', 'mutation'),
+            )
+            if updateStructuralTypes
+            else STRUCTURAL_VARIANT_ALIASES
+        )
         # remove potential structural type aliases
-        variant_types_details = list(filter(lambda x: False if x['name'] in structural_types else True, variant_types_details))
+        variant_types_details = list(
+            filter(
+                lambda x: False if x['name'] in structural_types else True, variant_types_details
+            )
+        )
 
     # convert to RIDs
     types = convert_to_rid_list(variant_types_details)
-
 
     # MATCHING POSITIONAL VARIANT, REGARDLESS OF POSITIONS
     # match the existing mutations (positional)
@@ -638,7 +641,6 @@ def match_positional_variant(
                 ignore_cache=ignore_cache,
             )
         )
-
 
     matches.extend(
         conn.query(

--- a/graphkb/match.py
+++ b/graphkb/match.py
@@ -272,7 +272,7 @@ def compare_positional_variants(
     generic: bool = True,
 ) -> bool:
     """
-    Compare 2 variant records from GraphKB to determine if they are equivalent
+    Compare 2 positional variant records from GraphKB to determine if they are equivalent
 
     Args:
         reference_variant: record used as a reference to be match to

--- a/tests/data.py
+++ b/tests/data.py
@@ -155,10 +155,10 @@ structuralVariants = {
             ],
         },
     },
-    "STK11:e.1_100del": {
+    "FANCM:e.2del": {
         "matches": {
             "displayName": [
-                "STK11 mutation",
+                "FANCM mutation",
             ],
             "type": [
                 "mutation",
@@ -166,28 +166,10 @@ structuralVariants = {
         },
         "does_not_matches": {
             "displayName": [
-                "STK11 deletion",
+                "FANCM structural variant",
             ],
             "type": [
-                "deletion",
-            ],
-        },
-    },
-    "STK11:i.1_100del": {
-        "matches": {
-            "displayName": [
-                "STK11 mutation",
-            ],
-            "type": [
-                "mutation",
-            ],
-        },
-        "does_not_matches": {
-            "displayName": [
-                "STK11 deletion",
-            ],
-            "type": [
-                "deletion",
+                "structural variant",
             ],
         },
     },

--- a/tests/test_match.py
+++ b/tests/test_match.py
@@ -551,7 +551,10 @@ class TestTypeScreening:
             assert match.structural_type_screening(conn, {"type": type}) == True
         for type in TestTypeScreening.ambiguous_structural:
             # w/ reference2
-            assert match.structural_type_screening(conn, {"type": type, "reference2": "#123:45"}) == True
+            assert (
+                match.structural_type_screening(conn, {"type": type, "reference2": "#123:45"})
+                == True
+            )
             # w/ cytoband coordinates
             assert match.structural_type_screening(conn, {"type": type, "prefix": "y"}) == True
 


### PR DESCRIPTION
See https://www.bcgsc.ca/jira/browse/KBDEV-1133.

Introducing type filterring earlier in the matching process.
Had to refactor the structural variant screening.

This PR is fixing the "wrong type" issue regarding matching same position, but might introduce a new dilemma with delins since they won't be matched anymore to the more specific types deletion or insertion. 