### PR TITLE
lint noqa of flake8 errors in test_statement.py from pytest fixture.

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -10,7 +10,7 @@ include_trailing_comma = true
 [metadata]
 name = graphkb
 url = https://github.com/bcgsc/pori_graphkb_python
-version = 1.13.0
+version = 1.14.0
 author_email = graphkb@bcgsc.ca
 description = python adapter for interacting with the GraphKB API
 long_description = file: README.md

--- a/tests/test_statement.py
+++ b/tests/test_statement.py
@@ -5,7 +5,9 @@ import pytest
 
 from graphkb import statement
 
-from .test_match import conn
+from .test_match import (  # noqa - 'F401 imported but unused' is being fooled by pytest conventions
+    conn,
+)
 
 EXCLUDE_INTEGRATION_TESTS = os.environ.get("EXCLUDE_INTEGRATION_TESTS") == "1"
 
@@ -86,7 +88,7 @@ class TestCategorizeRelevance:
 
 @pytest.mark.skipif(EXCLUDE_INTEGRATION_TESTS, reason="excluding long running integration tests")
 class TestStatementMatch:
-    def test_truncating_categories(self, conn):
+    def test_truncating_categories(self, conn):  # noqa - pytest fixture, not redefinition
         variant = {"@class": "CategoryVariant", "@rid": "#161:429", "displayName": "RB1 truncating"}
         statements = statement.get_statements_from_variants(conn, [variant])
         assert statements


### PR DESCRIPTION
Just to remove confusing linting warnings