### PR TITLE
Feature/make preferred gene source configurable

### DIFF
--- a/graphkb/genes.py
+++ b/graphkb/genes.py
@@ -219,7 +219,9 @@ def get_preferred_gene_name(
 
     gene_names = [g["displayName"] for g in genes if g]
     if 'ENS' in gene_name:
-        import pdb; pdb.set_trace()
+        import pdb
+
+        pdb.set_trace()
     if len(gene_names) > 1:
         logger.error(
             f"Multiple gene names found for: {gene_name} - using {gene_names[0]}, ignoring {gene_names[1:]}"
@@ -227,7 +229,9 @@ def get_preferred_gene_name(
     return gene_names[0]
 
 
-def get_cancer_predisposition_info(conn: GraphKBConnection, source: str = PREFERRED_GENE_SOURCE) -> Tuple[List[str], Dict[str, str]]:
+def get_cancer_predisposition_info(
+    conn: GraphKBConnection, source: str = PREFERRED_GENE_SOURCE
+) -> Tuple[List[str], Dict[str, str]]:
     """
     Return two lists from GraphKB, one of cancer predisposition genes and one of associated variants.
 
@@ -308,7 +312,9 @@ def get_cancer_predisposition_info(conn: GraphKBConnection, source: str = PREFER
     return sorted(genes), variants
 
 
-def get_pharmacogenomic_info(conn: GraphKBConnection, source: str = PREFERRED_GENE_SOURCE) -> Tuple[List[str], Dict[str, str]]:
+def get_pharmacogenomic_info(
+    conn: GraphKBConnection, source: str = PREFERRED_GENE_SOURCE
+) -> Tuple[List[str], Dict[str, str]]:
     """
     Return two lists from GraphKB, one of pharmacogenomic genes and one of associated variants.
 

--- a/graphkb/genes.py
+++ b/graphkb/genes.py
@@ -218,10 +218,6 @@ def get_preferred_gene_name(
             genes = source_filtered_genes
 
     gene_names = [g["displayName"] for g in genes if g]
-    if 'ENS' in gene_name:
-        import pdb
-
-        pdb.set_trace()
     if len(gene_names) > 1:
         logger.error(
             f"Multiple gene names found for: {gene_name} - using {gene_names[0]}, ignoring {gene_names[1:]}"

--- a/graphkb/genes.py
+++ b/graphkb/genes.py
@@ -218,6 +218,8 @@ def get_preferred_gene_name(
             genes = source_filtered_genes
 
     gene_names = [g["displayName"] for g in genes if g]
+    if 'ENS' in gene_name:
+        import pdb; pdb.set_trace()
     if len(gene_names) > 1:
         logger.error(
             f"Multiple gene names found for: {gene_name} - using {gene_names[0]}, ignoring {gene_names[1:]}"
@@ -225,7 +227,7 @@ def get_preferred_gene_name(
     return gene_names[0]
 
 
-def get_cancer_predisposition_info(conn: GraphKBConnection) -> Tuple[List[str], Dict[str, str]]:
+def get_cancer_predisposition_info(conn: GraphKBConnection, source: str = PREFERRED_GENE_SOURCE) -> Tuple[List[str], Dict[str, str]]:
     """
     Return two lists from GraphKB, one of cancer predisposition genes and one of associated variants.
 
@@ -287,7 +289,7 @@ def get_cancer_predisposition_info(conn: GraphKBConnection) -> Tuple[List[str], 
                     if name and biotype == "gene":
                         genes.add(name)
                     elif name:
-                        gene = get_preferred_gene_name(conn, name)
+                        gene = get_preferred_gene_name(conn, name, source)
                         if gene:
                             infer_genes.add((gene, name, biotype))
                         else:
@@ -306,7 +308,7 @@ def get_cancer_predisposition_info(conn: GraphKBConnection) -> Tuple[List[str], 
     return sorted(genes), variants
 
 
-def get_pharmacogenomic_info(conn: GraphKBConnection) -> Tuple[List[str], Dict[str, str]]:
+def get_pharmacogenomic_info(conn: GraphKBConnection, source: str = PREFERRED_GENE_SOURCE) -> Tuple[List[str], Dict[str, str]]:
     """
     Return two lists from GraphKB, one of pharmacogenomic genes and one of associated variants.
 
@@ -362,7 +364,7 @@ def get_pharmacogenomic_info(conn: GraphKBConnection) -> Tuple[List[str], Dict[s
                     if name and biotype == "gene":
                         genes.add(name)
                     elif name:
-                        gene = get_preferred_gene_name(conn, name)
+                        gene = get_preferred_gene_name(conn, name, source)
                         if gene:
                             infer_genes.add((gene, name, biotype))
                         else:


### PR DESCRIPTION
adds optional preferred-source arg to functions that call get_preferred_gene_name. This is because the value used is an rid which will be different in different instances of the db. To make this function usable with a non-bcgsc pori instance, the value needs to be settable.