### PR TITLE
SDEV-4155 - switch to source.displayName for Pharmacogenomic filterin…

### DIFF
--- a/graphkb/constants.py
+++ b/graphkb/constants.py
@@ -66,7 +66,7 @@ TUMOUR_SUPPRESSIVE = "tumour suppressive"
 CANCER_GENE = "cancer gene"
 FUSION_NAMES = ["structural variant", "fusion"]
 
-PHARMACOGENOMIC_SOURCE_EXCLUDE_LIST = ["cancer genome interpreter", "civic"]
+GSC_PHARMACOGENOMIC_SOURCE_DISPLAYNAME_EXCLUDE_LIST = ["CGI", "CIViC"]
 
 BASE_THERAPEUTIC_TERMS = ["therapeutic efficacy", "eligibility"]
 # the order here is the order these are applied, the first category matched is returned

--- a/graphkb/genes.py
+++ b/graphkb/genes.py
@@ -10,7 +10,7 @@ from .constants import (
     GENE_RETURN_PROPERTIES,
     ONCOGENE,
     ONCOKB_SOURCE_NAME,
-    PHARMACOGENOMIC_SOURCE_EXCLUDE_LIST,
+    GSC_PHARMACOGENOMIC_SOURCE_DISPLAYNAME_EXCLUDE_LIST,
     PREFERRED_GENE_SOURCE,
     RELEVANCE_BASE_TERMS,
     TSO500_SOURCE_NAME,
@@ -349,12 +349,13 @@ def get_pharmacogenomic_info(
                 "conditions.reference2.biotype",
                 "conditions.reference2.displayName",
                 "source.name",
+                "source.displayName",
             ],
         },
         ignore_cache=False,
     ):
         if record["source"]:  # type: ignore
-            if record["source"]["name"].lower() in PHARMACOGENOMIC_SOURCE_EXCLUDE_LIST:  # type: ignore
+            if record["source"]["displayName"] in GSC_PHARMACOGENOMIC_SOURCE_DISPLAYNAME_EXCLUDE_LIST:  # type: ignore
                 continue
 
         for condition in record["conditions"]:  # type: ignore


### PR DESCRIPTION
…g - so same properties can be used to filter pori_ipr_python kbmatches.  Replaced PHARMACOGENOMIC_SOURCE_EXCLUDE_LIST with GSC_PHARMACOGENOMIC_SOURCE_DISPLAYNAME_EXCLUDE_LIST.